### PR TITLE
Checkpoint issue, minor fixes, bidirectional selection

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/db/DatabaseHelper.java
+++ b/app/src/main/java/org/moire/opensudoku/db/DatabaseHelper.java
@@ -34,7 +34,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
 	private static final String TAG = "DatabaseHelper";
 
-	public static final int DATABASE_VERSION = 8;
+	public static final int DATABASE_VERSION = 9;
 
 	private Context mContext;
 
@@ -53,7 +53,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 				+ SudokuColumns.TIME + " INTEGER,"
 				+ SudokuColumns.LAST_PLAYED + " INTEGER,"
 				+ SudokuColumns.DATA + " Text,"
-				+ SudokuColumns.PUZZLE_NOTE + " Text"
+				+ SudokuColumns.PUZZLE_NOTE + " Text,"
+				+ SudokuColumns.COMMAND_STACK + " Text"
 				+ ");");
 
 		db.execSQL("CREATE TABLE " + SudokuDatabase.FOLDER_TABLE_NAME + " ("
@@ -166,7 +167,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
 	// TODO: sudokuName is not used
 	private void insertSudoku(SQLiteDatabase db, long folderID, long sudokuID, String sudokuName, String data) {
-		String sql = "INSERT INTO " + SudokuDatabase.SUDOKU_TABLE_NAME + " VALUES (" + sudokuID + ", " + folderID + ", 0, " + SudokuGame.GAME_STATE_NOT_STARTED + ", 0, null, '" + data + "', null);";
+		String sql = "INSERT INTO " + SudokuDatabase.SUDOKU_TABLE_NAME + " VALUES (" + sudokuID + ", " + folderID + ", 0, " + SudokuGame.GAME_STATE_NOT_STARTED + ", 0, null, '" + data + "', null, null);";
 		db.execSQL(sql);
 	}
 
@@ -174,8 +175,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
 		Log.i(TAG, "Upgrading database from version " + oldVersion + " to "
 				+ newVersion + "");
+		if (oldVersion <=7 ) {
+			createIndexes(db);
+		}
 
-		createIndexes(db);
+		if (oldVersion <= 8) {
+			db.execSQL("ALTER TABLE " + SudokuDatabase.SUDOKU_TABLE_NAME + " ADD COLUMN " + SudokuColumns.COMMAND_STACK + " TEXT");
+		}
 	}
 
 	private void createIndexes(SQLiteDatabase db) {

--- a/app/src/main/java/org/moire/opensudoku/db/SudokuColumns.java
+++ b/app/src/main/java/org/moire/opensudoku/db/SudokuColumns.java
@@ -30,4 +30,5 @@ public abstract class SudokuColumns implements BaseColumns {
 	public static final String LAST_PLAYED = "last_played";
 	public static final String DATA = "data";
 	public static final String PUZZLE_NOTE = "puzzle_note";
+	public static final String COMMAND_STACK = "command_stack";
 }

--- a/app/src/main/java/org/moire/opensudoku/db/SudokuImportParams.java
+++ b/app/src/main/java/org/moire/opensudoku/db/SudokuImportParams.java
@@ -9,6 +9,7 @@ public class SudokuImportParams {
 	public long lastPlayed;
 	public String data;
 	public String note;
+	public String command_stack;
 
 	public void clear() {
 		created = 0;
@@ -17,5 +18,6 @@ public class SudokuImportParams {
 		lastPlayed = 0;
 		data = null;
 		note = null;
+		command_stack = null;
 	}
 }

--- a/app/src/main/java/org/moire/opensudoku/game/Cell.java
+++ b/app/src/main/java/org/moire/opensudoku/game/Cell.java
@@ -243,7 +243,7 @@ public class Cell {
 	 * created by {@link #serialize(StringBuilder)} or {@link #serialize()} method).
 	 * earlier.
 	 *
-	 * @param note
+	 * @param cellData
 	 */
 	public static Cell deserialize(String cellData) {
 		StringTokenizer data = new StringTokenizer(cellData, "|");

--- a/app/src/main/java/org/moire/opensudoku/game/Cell.java
+++ b/app/src/main/java/org/moire/opensudoku/game/Cell.java
@@ -260,7 +260,7 @@ public class Cell {
 	public void serialize(StringBuilder data) {
 		data.append(mValue).append("|");
 		if (mNote == null || mNote.isEmpty()) {
-			data.append("-").append("|");
+			data.append("0").append("|");
 		} else {
 			mNote.serialize(data);
 			data.append("|");

--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -143,6 +143,19 @@ public class CellCollection {
 		return mCells[rowIndex][colIndex];
 	}
 
+
+	public Cell findFirstCell(int val) {
+		for (int r = 0; r < SUDOKU_SIZE; r++) {
+			for (int c = 0; c < SUDOKU_SIZE; c++) {
+				Cell cell = mCells[r][c];
+				if (cell.getValue() == val)
+					return cell;
+			}
+		}
+		return null;
+	}
+
+
 	public void markAllCellsAsValid() {
 		mOnChangeEnabled = false;
 		for (int r = 0; r < SUDOKU_SIZE; r++) {

--- a/app/src/main/java/org/moire/opensudoku/game/CellNote.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellNote.java
@@ -107,7 +107,7 @@ public class CellNote {
 
         List<Integer> result = new ArrayList<>();
 	    int c = 1;
-	    for (int i =0; i<9; i++){
+	    for (int i = 0; i < 9; i++) {
 	        if ((mNotedNumbers & (short)c) != 0) {
                 result.add(i + 1);
             }

--- a/app/src/main/java/org/moire/opensudoku/game/CellNote.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellNote.java
@@ -90,6 +90,7 @@ public class CellNote {
 	 */
 	public void serialize(StringBuilder data) {
         data.append((int)mNotedNumbers);
+		data.append("|");
 	}
 
 	public String serialize() {

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -309,7 +309,6 @@ public class SudokuGame {
 		mCommandStack = new CommandStack(mCells);
 		validate();
 		setTime(0);
-        resume();
 		setLastPlayed(0);
 		mState = GAME_STATE_NOT_STARTED;
 	}

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -47,7 +47,7 @@ public class SudokuGame {
 	private OnPuzzleSolvedListener mOnPuzzleSolvedListener;
     private OnUndoOccurredListener mOnUndoOccurredListener;
 	private CommandStack mCommandStack;
-	// Time when current activity has become active. 
+	// Time when current activity has become active.
 	private long mActiveFromTime = -1;
 
 	public static SudokuGame createEmptyGame() {
@@ -74,8 +74,7 @@ public class SudokuGame {
 		outState.putLong("time", mTime);
 		outState.putLong("lastPlayed", mLastPlayed);
 		outState.putString("cells", mCells.serialize());
-
-		mCommandStack.saveState(outState);
+		outState.putString("command_stack", mCommandStack.serialize());
 	}
 
 	public void restoreState(Bundle inState) {
@@ -86,9 +85,7 @@ public class SudokuGame {
 		mTime = inState.getLong("time");
 		mLastPlayed = inState.getLong("lastPlayed");
 		mCells = CellCollection.deserialize(inState.getString("cells"));
-
-		mCommandStack = new CommandStack(mCells);
-		mCommandStack.restoreState(inState);
+		mCommandStack = CommandStack.deserialize(inState.getString("command_stack"), mCells);
 
 		validate();
 	}
@@ -172,6 +169,14 @@ public class SudokuGame {
 
 	public long getId() {
 		return mId;
+	}
+
+		public void setCommandStack(CommandStack commandStack) {
+		mCommandStack = commandStack;
+	}
+
+	public CommandStack getCommandStack() {
+		return mCommandStack;
 	}
 
 	/**
@@ -284,7 +289,7 @@ public class SudokuGame {
 	 * Pauses game-play (for example if activity pauses).
 	 */
 	public void pause() {
-		// save time we have spent playing so far - it will be reseted after resuming 
+		// save time we have spent playing so far - it will be reseted after resuming
 		mTime += SystemClock.uptimeMillis() - mActiveFromTime;
 		mActiveFromTime = -1;
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
@@ -38,27 +38,17 @@ public abstract class AbstractCommand {
 			return new FillInNotesCommand();
 		} else if (commandClass.equals(SetCellValueCommand.class.getSimpleName())) {
 			return new SetCellValueCommand();
+		} else if (commandClass.equals(CheckpointCommand.class.getSimpleName())) {
+			return new CheckpointCommand();
 		} else {
 			throw new IllegalArgumentException(String.format("Unknown command class '%s'.", commandClass));
 		}
 	}
 
-	private boolean mIsCheckpoint;
-
 	void saveState(Bundle outState) {
-		outState.putBoolean("isCheckpoint", mIsCheckpoint);
 	}
 
 	void restoreState(Bundle inState) {
-		mIsCheckpoint = inState.getBoolean("isCheckpoint");
-	}
-
-	public boolean isCheckpoint() {
-		return mIsCheckpoint;
-	}
-
-	public void setCheckpoint(boolean isCheckpoint) {
-		mIsCheckpoint = isCheckpoint;
 	}
 
 	public String getCommandClass() {

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
@@ -20,7 +20,7 @@
 
 package org.moire.opensudoku.game.command;
 
-import android.os.Bundle;
+import java.util.StringTokenizer;
 
 /**
  * Generic interface for command in application.
@@ -29,27 +29,74 @@ import android.os.Bundle;
  */
 public abstract class AbstractCommand {
 
-	public static AbstractCommand newInstance(String commandClass) {
-		if (commandClass.equals(ClearAllNotesCommand.class.getSimpleName())) {
-			return new ClearAllNotesCommand();
-		} else if (commandClass.equals(EditCellNoteCommand.class.getSimpleName())) {
-			return new EditCellNoteCommand();
-		} else if (commandClass.equals(FillInNotesCommand.class.getSimpleName())) {
-			return new FillInNotesCommand();
-		} else if (commandClass.equals(SetCellValueCommand.class.getSimpleName())) {
-			return new SetCellValueCommand();
-		} else if (commandClass.equals(CheckpointCommand.class.getSimpleName())) {
-			return new CheckpointCommand();
-		} else {
-			throw new IllegalArgumentException(String.format("Unknown command class '%s'.", commandClass));
-		}
-	}
+    private interface CommandCreatorFunction {
+        AbstractCommand create();
+    }
 
-	void saveState(Bundle outState) {
-	}
+    private static class CommandDef {
+        String mLongName;
+        String mShortName;
+        CommandCreatorFunction mCreator;
 
-	void restoreState(Bundle inState) {
-	}
+        public CommandDef(String longName, String shortName, CommandCreatorFunction creator){
+            mLongName = longName;
+            mShortName = shortName;
+            mCreator = creator;
+        }
+
+        public AbstractCommand create() {
+            return mCreator.create();
+        }
+
+        public String getLongName() {
+            return mLongName;
+        }
+
+        public String getShortName() {
+            return mShortName;
+        }
+    }
+
+    private static final CommandDef[] commands = {
+            new CommandDef(ClearAllNotesCommand.class.getSimpleName(),"c1",
+                    new CommandCreatorFunction() { public AbstractCommand create() {return new ClearAllNotesCommand();} }),
+            new CommandDef(EditCellNoteCommand.class.getSimpleName(),"c2",
+                    new CommandCreatorFunction() { public AbstractCommand create() {return new EditCellNoteCommand();} }),
+            new CommandDef(FillInNotesCommand.class.getSimpleName(),"c3",
+                    new CommandCreatorFunction() { public AbstractCommand create() {return new FillInNotesCommand();} }),
+            new CommandDef(SetCellValueCommand.class.getSimpleName(),"c4",
+                    new CommandCreatorFunction() { public AbstractCommand create() {return new SetCellValueCommand();} }),
+            new CommandDef(CheckpointCommand.class.getSimpleName(),"c5",
+                    new CommandCreatorFunction() { public AbstractCommand create() {return new CheckpointCommand();} })
+    };
+
+	public static AbstractCommand deserialize(StringTokenizer data) {
+		String cmdShortName = data.nextToken();
+        for (CommandDef cmdDef: commands) {
+            if (cmdDef.getShortName().equals(cmdShortName)) {
+                AbstractCommand cmd = cmdDef.create();
+                cmd._deserialize(data);
+                return cmd;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Unknown command class '%s'.", cmdShortName));
+    }
+
+    protected void _deserialize(StringTokenizer data) {
+
+    }
+
+    public void serialize(StringBuilder data) {
+        String cmdLongName = getCommandClass();
+        for (CommandDef cmdDef: commands) {
+            if (cmdDef.getLongName().equals(cmdLongName)) {
+                data.append(cmdDef.getShortName()).append("|");
+                return;
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Unknown command class '%s'.", cmdLongName));
+    }
 
 	public String getCommandClass() {
 		return getClass().getSimpleName();

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
@@ -1,0 +1,52 @@
+package org.moire.opensudoku.game.command;
+
+import android.os.Bundle;
+
+import org.moire.opensudoku.game.Cell;
+
+/**
+ * Created by spimanov on 30.10.17.
+ */
+
+public abstract class AbstractSingleCellCommand extends AbstractCellCommand {
+
+    private int mCellRow;
+    private int mCellColumn;
+
+    public AbstractSingleCellCommand(Cell cell){
+        mCellRow = cell.getRowIndex();
+        mCellColumn = cell.getColumnIndex();
+    }
+
+    AbstractSingleCellCommand() {
+
+    }
+
+    @Override
+    void saveState(Bundle outState) {
+        super.saveState(outState);
+
+        outState.putInt("cellRow", mCellRow);
+        outState.putInt("cellColumn", mCellColumn);
+    }
+
+    @Override
+    void restoreState(Bundle inState) {
+        super.restoreState(inState);
+
+        mCellRow = inState.getInt("cellRow");
+        mCellColumn = inState.getInt("cellColumn");
+    }
+
+    Cell getCell() {
+        return getCells().getCell(mCellRow, mCellColumn);
+    }
+
+    public int getCellRow() {
+        return mCellRow;
+    }
+
+    public int getCellColumn() {
+        return mCellColumn;
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
@@ -1,8 +1,7 @@
 package org.moire.opensudoku.game.command;
 
-import android.os.Bundle;
-
 import org.moire.opensudoku.game.Cell;
+import java.util.StringTokenizer;
 
 /**
  * Created by spimanov on 30.10.17.
@@ -23,19 +22,19 @@ public abstract class AbstractSingleCellCommand extends AbstractCellCommand {
     }
 
     @Override
-    void saveState(Bundle outState) {
-        super.saveState(outState);
+    public void serialize(StringBuilder data) {
+        super.serialize(data);
 
-        outState.putInt("cellRow", mCellRow);
-        outState.putInt("cellColumn", mCellColumn);
+        data.append(mCellRow).append("|");
+        data.append(mCellColumn).append("|");
     }
 
     @Override
-    void restoreState(Bundle inState) {
-        super.restoreState(inState);
+    protected void _deserialize(StringTokenizer data) {
+        super._deserialize(data);
 
-        mCellRow = inState.getInt("cellRow");
-        mCellColumn = inState.getInt("cellColumn");
+        mCellRow = Integer.parseInt(data.nextToken());
+        mCellColumn  = Integer.parseInt(data.nextToken());
     }
 
     Cell getCell() {

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractSingleCellCommand.java
@@ -37,15 +37,8 @@ public abstract class AbstractSingleCellCommand extends AbstractCellCommand {
         mCellColumn  = Integer.parseInt(data.nextToken());
     }
 
-    Cell getCell() {
+    public Cell getCell() {
         return getCells().getCell(mCellRow, mCellColumn);
     }
 
-    public int getCellRow() {
-        return mCellRow;
-    }
-
-    public int getCellColumn() {
-        return mCellColumn;
-    }
 }

--- a/app/src/main/java/org/moire/opensudoku/game/command/CheckpointCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CheckpointCommand.java
@@ -1,0 +1,32 @@
+package org.moire.opensudoku.game.command;
+
+import android.os.Bundle;
+
+/**
+ * Created by spimanov on 29.10.17.
+ */
+
+public class CheckpointCommand extends AbstractCommand {
+
+    public CheckpointCommand() {
+    }
+
+    @Override
+    void saveState(Bundle outState) {
+        super.saveState(outState);
+    }
+
+    @Override
+    void restoreState(Bundle inState) {
+        super.restoreState(inState);
+    }
+
+    @Override
+    void execute() {
+    }
+
+    @Override
+    void undo() {
+    }
+
+}

--- a/app/src/main/java/org/moire/opensudoku/game/command/CheckpointCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CheckpointCommand.java
@@ -1,7 +1,5 @@
 package org.moire.opensudoku.game.command;
 
-import android.os.Bundle;
-
 /**
  * Created by spimanov on 29.10.17.
  */
@@ -9,16 +7,6 @@ import android.os.Bundle;
 public class CheckpointCommand extends AbstractCommand {
 
     public CheckpointCommand() {
-    }
-
-    @Override
-    void saveState(Bundle outState) {
-        super.saveState(outState);
-    }
-
-    @Override
-    void restoreState(Bundle inState) {
-        super.restoreState(inState);
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/game/command/ClearAllNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/ClearAllNotesCommand.java
@@ -22,9 +22,7 @@ package org.moire.opensudoku.game.command;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import android.os.Bundle;
-
+import java.util.StringTokenizer;
 import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.CellCollection;
 import org.moire.opensudoku.game.CellNote;
@@ -39,37 +37,28 @@ public class ClearAllNotesCommand extends AbstractCellCommand {
 
 
 	@Override
-	void saveState(Bundle outState) {
-		super.saveState(outState);
+	public void serialize(StringBuilder data) {
+		super.serialize(data);
 
-		int[] rows = new int[mOldNotes.size()];
-		int[] cols = new int[mOldNotes.size()];
-		String[] notes = new String[mOldNotes.size()];
+		data.append(mOldNotes.size()).append("|");
 
-		int i = 0;
 		for (NoteEntry ne : mOldNotes) {
-			rows[i] = ne.rowIndex;
-			cols[i] = ne.colIndex;
-			notes[i] = ne.note.serialize();
-			i++;
+            data.append(ne.rowIndex).append("|");
+            data.append(ne.colIndex).append("|");
+			ne.note.serialize(data);
 		}
-
-		outState.putIntArray("rows", rows);
-		outState.putIntArray("cols", cols);
-		outState.putStringArray("notes", notes);
 	}
 
 	@Override
-	void restoreState(Bundle inState) {
-		super.restoreState(inState);
+	protected void _deserialize(StringTokenizer data) {
+		super._deserialize(data);
 
-		int[] rows = inState.getIntArray("rows");
-		int[] cols = inState.getIntArray("cols");
-		String[] notes = inState.getStringArray("notes");
+        int notesSize = Integer.parseInt(data.nextToken());
+		for (int i = 0; i < notesSize; i++) {
+            int row = Integer.parseInt(data.nextToken());
+            int col = Integer.parseInt(data.nextToken());
 
-		for (int i = 0; i < rows.length; i++) {
-			mOldNotes.add(new NoteEntry(rows[i], cols[i], CellNote
-					.deserialize(notes[i])));
+            mOldNotes.add(new NoteEntry(row, col, CellNote.deserialize(data.nextToken())));
 		}
 	}
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
@@ -1,5 +1,7 @@
 package org.moire.opensudoku.game.command;
 
+import java.util.Iterator;
+import java.util.ListIterator;
 import java.util.Stack;
 
 import org.moire.opensudoku.game.CellCollection;
@@ -61,8 +63,7 @@ public class CommandStack {
 			if (c instanceof CheckpointCommand)
 				return;
 		}
-		AbstractCommand command = AbstractCommand.newInstance(CheckpointCommand.class.getSimpleName());
-		push(command);
+		push(new CheckpointCommand());
 	}
 
 	public boolean hasCheckpoint() {
@@ -83,9 +84,8 @@ public class CommandStack {
 			c = mCommandStack.pop();
 			c.undo();
 
-			if (mCommandStack.empty() || c instanceof CheckpointCommand) {
-				break;
-			}
+			if (c instanceof CheckpointCommand)
+			    break;
 		}
 		validateCells();
 	}
@@ -95,10 +95,21 @@ public class CommandStack {
 		return mCommandStack.size() != 0;
 	}
 
+	public AbstractSingleCellCommand findLatestSingleCellCommand() {
+        ListIterator<AbstractCommand> iter = mCommandStack.listIterator(mCommandStack.size());
+        while (iter.hasPrevious()) {
+            AbstractCommand o = iter.previous();
+            if (o instanceof AbstractSingleCellCommand)
+                return (AbstractSingleCellCommand) o;
+        }
+
+        return null;
+    }
+
 	private void push(AbstractCommand command) {
 		if (command instanceof AbstractCellCommand) {
 			((AbstractCellCommand) command).setCells(mCells);
-		}
+        }
 		mCommandStack.push(command);
 	}
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
@@ -1,12 +1,9 @@
 package org.moire.opensudoku.game.command;
 
-import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Stack;
-
+import java.util.StringTokenizer;
 import org.moire.opensudoku.game.CellCollection;
-
-import android.os.Bundle;
 
 public class CommandStack {
 	private Stack<AbstractCommand> mCommandStack = new Stack<AbstractCommand>();
@@ -19,26 +16,35 @@ public class CommandStack {
 		mCells = cells;
 	}
 
-	public void saveState(Bundle outState) {
-		outState.putInt("cmdStack.size", mCommandStack.size());
-		for (int i = 0; i < mCommandStack.size(); i++) {
-			AbstractCommand command = mCommandStack.get(i);
-			Bundle commandState = new Bundle();
-			commandState.putString("commandClass", command.getCommandClass());
-			command.saveState(commandState);
-			outState.putBundle("cmdStack." + i, commandState);
-		}
-	}
+    public static CommandStack deserialize(String data, CellCollection cells) {
+        StringTokenizer st = new StringTokenizer(data, "|");
+        return deserialize(st, cells);
+    }
 
-	public void restoreState(Bundle inState) {
-		int stackSize = inState.getInt("cmdStack.size");
-		for (int i = 0; i < stackSize; i++) {
-			Bundle commandState = inState.getBundle("cmdStack." + i);
-			AbstractCommand command = AbstractCommand.newInstance(commandState.getString("commandClass"));
-			command.restoreState(commandState);
-			push(command);
-		}
-	}
+    public static CommandStack deserialize(StringTokenizer data, CellCollection cells) {
+	    CommandStack result = new CommandStack(cells);
+        int stackSize = Integer.parseInt(data.nextToken());
+        for (int i = 0; i < stackSize; i++) {
+            AbstractCommand command = AbstractCommand.deserialize(data);
+            result.push(command);
+        }
+
+        return result;
+    }
+
+    public String serialize() {
+        StringBuilder sb = new StringBuilder();
+        serialize(sb);
+        return sb.toString();
+    }
+
+    public void serialize(StringBuilder data) {
+        data.append(mCommandStack.size()).append("|");
+        for (int i = 0; i < mCommandStack.size(); i++) {
+            AbstractCommand command = mCommandStack.get(i);
+            command.serialize(data);
+        }
+    }
 
 	public boolean empty() {
 		return mCommandStack.empty();

--- a/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
@@ -58,13 +58,16 @@ public class CommandStack {
 	public void setCheckpoint() {
 		if (!mCommandStack.empty()) {
 			AbstractCommand c = mCommandStack.peek();
-			c.setCheckpoint(true);
+			if (c instanceof CheckpointCommand)
+				return;
 		}
+		AbstractCommand command = AbstractCommand.newInstance(CheckpointCommand.class.getSimpleName());
+		push(command);
 	}
 
 	public boolean hasCheckpoint() {
 		for (AbstractCommand c : mCommandStack) {
-			if (c.isCheckpoint())
+			if (c instanceof CheckpointCommand)
 				return true;
 		}
 		return false;
@@ -80,7 +83,7 @@ public class CommandStack {
 			c = mCommandStack.pop();
 			c.undo();
 
-			if (mCommandStack.empty() || mCommandStack.peek().isCheckpoint()) {
+			if (mCommandStack.empty() || c instanceof CheckpointCommand) {
 				break;
 			}
 		}

--- a/app/src/main/java/org/moire/opensudoku/game/command/EditCellNoteCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/EditCellNoteCommand.java
@@ -24,16 +24,13 @@ import android.os.Bundle;
 import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.CellNote;
 
-public class EditCellNoteCommand extends AbstractCellCommand {
+public class EditCellNoteCommand extends AbstractSingleCellCommand {
 
-	private int mCellRow;
-	private int mCellColumn;
 	private CellNote mNote;
 	private CellNote mOldNote;
 
 	public EditCellNoteCommand(Cell cell, CellNote note) {
-		mCellRow = cell.getRowIndex();
-		mCellColumn = cell.getColumnIndex();
+		super(cell);
 		mNote = note;
 	}
 
@@ -45,8 +42,6 @@ public class EditCellNoteCommand extends AbstractCellCommand {
 	void saveState(Bundle outState) {
 		super.saveState(outState);
 
-		outState.putInt("cellRow", mCellRow);
-		outState.putInt("cellColumn", mCellColumn);
 		outState.putString("note", mNote.serialize());
 		outState.putString("oldNote", mOldNote.serialize());
 	}
@@ -55,22 +50,20 @@ public class EditCellNoteCommand extends AbstractCellCommand {
 	void restoreState(Bundle inState) {
 		super.restoreState(inState);
 
-		mCellRow = inState.getInt("cellRow");
-		mCellColumn = inState.getInt("cellColumn");
 		mNote = CellNote.deserialize(inState.getString("note"));
 		mOldNote = CellNote.deserialize(inState.getString("oldNote"));
 	}
 
 	@Override
 	void execute() {
-		Cell cell = getCells().getCell(mCellRow, mCellColumn);
+		Cell cell = getCell();
 		mOldNote = cell.getNote();
 		cell.setNote(mNote);
 	}
 
 	@Override
 	void undo() {
-		Cell cell = getCells().getCell(mCellRow, mCellColumn);
+		Cell cell = getCell();
 		cell.setNote(mOldNote);
 	}
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/EditCellNoteCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/EditCellNoteCommand.java
@@ -20,9 +20,9 @@
 
 package org.moire.opensudoku.game.command;
 
-import android.os.Bundle;
 import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.CellNote;
+import java.util.StringTokenizer;
 
 public class EditCellNoteCommand extends AbstractSingleCellCommand {
 
@@ -39,19 +39,19 @@ public class EditCellNoteCommand extends AbstractSingleCellCommand {
 	}
 
 	@Override
-	void saveState(Bundle outState) {
-		super.saveState(outState);
+	public void serialize(StringBuilder data) {
+		super.serialize(data);
 
-		outState.putString("note", mNote.serialize());
-		outState.putString("oldNote", mOldNote.serialize());
+		mNote.serialize(data);
+		mOldNote.serialize(data);
 	}
 
 	@Override
-	void restoreState(Bundle inState) {
-		super.restoreState(inState);
+	protected void _deserialize(StringTokenizer data) {
+		super._deserialize(data);
 
-		mNote = CellNote.deserialize(inState.getString("note"));
-		mOldNote = CellNote.deserialize(inState.getString("oldNote"));
+		mNote = CellNote.deserialize(data.nextToken());
+		mOldNote = CellNote.deserialize(data.nextToken());
 	}
 
 	@Override

--- a/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
@@ -2,8 +2,7 @@ package org.moire.opensudoku.game.command;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import android.os.Bundle;
+import java.util.StringTokenizer;
 import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.CellCollection;
 import org.moire.opensudoku.game.CellGroup;
@@ -17,37 +16,28 @@ public class FillInNotesCommand extends AbstractCellCommand {
 	}
 
 	@Override
-	void saveState(Bundle outState) {
-		super.saveState(outState);
+	public void serialize(StringBuilder data) {
+		super.serialize(data);
 
-		int[] rows = new int[mOldNotes.size()];
-		int[] cols = new int[mOldNotes.size()];
-		String[] notes = new String[mOldNotes.size()];
+		data.append(mOldNotes.size()).append("|");
 
-		int i = 0;
 		for (NoteEntry ne : mOldNotes) {
-			rows[i] = ne.rowIndex;
-			cols[i] = ne.colIndex;
-			notes[i] = ne.note.serialize();
-			i++;
+			data.append(ne.rowIndex).append("|");
+			data.append(ne.colIndex).append("|");
+			ne.note.serialize(data);
 		}
-
-		outState.putIntArray("rows", rows);
-		outState.putIntArray("cols", cols);
-		outState.putStringArray("notes", notes);
 	}
 
 	@Override
-	void restoreState(Bundle inState) {
-		super.restoreState(inState);
+	protected void _deserialize(StringTokenizer data) {
+		super._deserialize(data);
 
-		int[] rows = inState.getIntArray("rows");
-		int[] cols = inState.getIntArray("cols");
-		String[] notes = inState.getStringArray("notes");
+		int notesSize = Integer.parseInt(data.nextToken());
+		for (int i = 0; i < notesSize; i++) {
+			int row = Integer.parseInt(data.nextToken());
+			int col = Integer.parseInt(data.nextToken());
 
-		for (int i = 0; i < rows.length; i++) {
-			mOldNotes.add(new NoteEntry(rows[i], cols[i], CellNote
-					.deserialize(notes[i])));
+			mOldNotes.add(new NoteEntry(row, col, CellNote.deserialize(data.nextToken())));
 		}
 	}
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
@@ -20,8 +20,8 @@
 
 package org.moire.opensudoku.game.command;
 
-import android.os.Bundle;
 import org.moire.opensudoku.game.Cell;
+import java.util.StringTokenizer;
 
 public class SetCellValueCommand extends AbstractSingleCellCommand {
 
@@ -38,19 +38,19 @@ public class SetCellValueCommand extends AbstractSingleCellCommand {
 	}
 
 	@Override
-	void saveState(Bundle outState) {
-		super.saveState(outState);
+	public void serialize(StringBuilder data) {
+		super.serialize(data);
 
-		outState.putInt("value", mValue);
-		outState.putInt("oldValue", mOldValue);
+		data.append(mValue).append("|");
+		data.append(mOldValue).append("|");
 	}
 
 	@Override
-	void restoreState(Bundle inState) {
-		super.restoreState(inState);
+	protected void _deserialize(StringTokenizer data) {
+		super._deserialize(data);
 
-		mValue = inState.getInt("value");
-		mOldValue = inState.getInt("oldValue");
+		mValue = Integer.parseInt(data.nextToken());
+		mOldValue = Integer.parseInt(data.nextToken());
 	}
 
 	@Override

--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
@@ -23,16 +23,13 @@ package org.moire.opensudoku.game.command;
 import android.os.Bundle;
 import org.moire.opensudoku.game.Cell;
 
-public class SetCellValueCommand extends AbstractCellCommand {
+public class SetCellValueCommand extends AbstractSingleCellCommand {
 
-	private int mCellRow;
-	private int mCellColumn;
 	private int mValue;
 	private int mOldValue;
 
 	public SetCellValueCommand(Cell cell, int value) {
-		mCellRow = cell.getRowIndex();
-		mCellColumn = cell.getColumnIndex();
+		super(cell);
 		mValue = value;
 	}
 
@@ -44,8 +41,6 @@ public class SetCellValueCommand extends AbstractCellCommand {
 	void saveState(Bundle outState) {
 		super.saveState(outState);
 
-		outState.putInt("cellRow", mCellRow);
-		outState.putInt("cellColumn", mCellColumn);
 		outState.putInt("value", mValue);
 		outState.putInt("oldValue", mOldValue);
 	}
@@ -54,22 +49,20 @@ public class SetCellValueCommand extends AbstractCellCommand {
 	void restoreState(Bundle inState) {
 		super.restoreState(inState);
 
-		mCellRow = inState.getInt("cellRow");
-		mCellColumn = inState.getInt("cellColumn");
 		mValue = inState.getInt("value");
 		mOldValue = inState.getInt("oldValue");
 	}
 
 	@Override
 	void execute() {
-		Cell cell = getCells().getCell(mCellRow, mCellColumn);
+		Cell cell = getCell();
 		mOldValue = cell.getValue();
 		cell.setValue(mValue);
 	}
 
 	@Override
 	void undo() {
-		Cell cell = getCells().getCell(mCellRow, mCellColumn);
+		Cell cell = getCell();
 		cell.setValue(mOldValue);
 	}
 

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
@@ -713,7 +713,7 @@ public class SudokuBoardView extends View {
 	 * @param col Columnd index of cell which should be selected.
 	 * @return True, if cell was successfuly selected.
 	 */
-	private boolean moveCellSelectionTo(int row, int col) {
+	public boolean moveCellSelectionTo(int row, int col) {
 		if (col >= 0 && col < CellCollection.SUDOKU_SIZE
 				&& row >= 0 && row < CellCollection.SUDOKU_SIZE) {
 			mSelectedCell = mCells.getCell(row, col);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
@@ -333,6 +333,10 @@ public class SudokuBoardView extends View {
 		}
 	}
 
+	public void invokeOnCellSelected() {
+		onCellSelected(mSelectedCell);
+	}
+
 	@Override
 	protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
 		int widthMode = MeasureSpec.getMode(widthMeasureSpec);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -406,6 +406,7 @@ public class SudokuPlayActivity extends Activity {
 								if (mShowTime) {
 									mGameTimer.start();
 								}
+								removeDialog(DIALOG_WELL_DONE);
 							}
 						})
 						.setNegativeButton(android.R.string.no, null)
@@ -453,6 +454,9 @@ public class SudokuPlayActivity extends Activity {
 
 		@Override
 		public void onPuzzleSolved() {
+			if (mShowTime) {
+				mGameTimer.stop();
+			}
 			mSudokuBoard.setReadOnly(true);
 			showDialog(DIALOG_WELL_DONE);
 		}

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -42,6 +42,7 @@ import org.moire.opensudoku.R;
 import org.moire.opensudoku.db.SudokuDatabase;
 import org.moire.opensudoku.game.SudokuGame;
 import org.moire.opensudoku.game.SudokuGame.OnPuzzleSolvedListener;
+import org.moire.opensudoku.game.SudokuGame.OnUndoOccurredListener;
 import org.moire.opensudoku.gui.inputmethod.IMControlPanel;
 import org.moire.opensudoku.gui.inputmethod.IMControlPanelStatePersister;
 import org.moire.opensudoku.gui.inputmethod.IMNumpad;
@@ -152,6 +153,7 @@ public class SudokuPlayActivity extends Activity {
 
 		mSudokuBoard.setGame(mSudokuGame);
 		mSudokuGame.setOnPuzzleSolvedListener(onSolvedListener);
+		mSudokuGame.setOnUndoOccurredListener(onUndoOccurredListener);
 
 		mHintsQueue.showOneTimeHint("welcome", R.string.welcome, R.string.first_run_hint);
 
@@ -447,6 +449,13 @@ public class SudokuPlayActivity extends Activity {
 			showDialog(DIALOG_WELL_DONE);
 		}
 
+	};
+
+	private OnUndoOccurredListener onUndoOccurredListener = new OnUndoOccurredListener() {
+		@Override
+		public void onUndoOccurred(int selectedCellRow, int selectedCellColumn) {
+			mSudokuBoard.moveCellSelectionTo(selectedCellRow, selectedCellColumn);
+		}
 	};
 
 	/**

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -40,9 +40,9 @@ import android.view.WindowManager;
 import android.widget.TextView;
 import org.moire.opensudoku.R;
 import org.moire.opensudoku.db.SudokuDatabase;
+import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.SudokuGame;
 import org.moire.opensudoku.game.SudokuGame.OnPuzzleSolvedListener;
-import org.moire.opensudoku.game.SudokuGame.OnUndoOccurredListener;
 import org.moire.opensudoku.gui.inputmethod.IMControlPanel;
 import org.moire.opensudoku.gui.inputmethod.IMControlPanelStatePersister;
 import org.moire.opensudoku.gui.inputmethod.IMNumpad;
@@ -153,7 +153,7 @@ public class SudokuPlayActivity extends Activity {
 
 		mSudokuBoard.setGame(mSudokuGame);
 		mSudokuGame.setOnPuzzleSolvedListener(onSolvedListener);
-		mSudokuGame.setOnUndoOccurredListener(onUndoOccurredListener);
+		selectLastChangedCell();
 
 		mHintsQueue.showOneTimeHint("welcome", R.string.welcome, R.string.first_run_hint);
 
@@ -344,6 +344,7 @@ public class SudokuPlayActivity extends Activity {
 				return true;
 			case MENU_ITEM_UNDO:
 				mSudokuGame.undo();
+				selectLastChangedCell();
 				return true;
 			case MENU_ITEM_SETTINGS:
 				Intent i = new Intent();
@@ -429,6 +430,7 @@ public class SudokuPlayActivity extends Activity {
 						.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 							public void onClick(DialogInterface dialog, int whichButton) {
 								mSudokuGame.undoToCheckpoint();
+								selectLastChangedCell();
 							}
 						})
 						.setNegativeButton(android.R.string.no, null)
@@ -438,9 +440,15 @@ public class SudokuPlayActivity extends Activity {
 		return null;
 	}
 
-	/**
-	 * Occurs when puzzle is solved.
-	 */
+	private void selectLastChangedCell() {
+		Cell cell = mSudokuGame.getLastChangedCell();
+		if (cell != null)
+			mSudokuBoard.moveCellSelectionTo(cell.getRowIndex(), cell.getColumnIndex());
+	};
+
+/**
+ * Occurs when puzzle is solved.
+ */
 	private OnPuzzleSolvedListener onSolvedListener = new OnPuzzleSolvedListener() {
 
 		@Override
@@ -449,13 +457,6 @@ public class SudokuPlayActivity extends Activity {
 			showDialog(DIALOG_WELL_DONE);
 		}
 
-	};
-
-	private OnUndoOccurredListener onUndoOccurredListener = new OnUndoOccurredListener() {
-		@Override
-		public void onUndoOccurred(int selectedCellRow, int selectedCellColumn) {
-			mSudokuBoard.moveCellSelectionTo(selectedCellRow, selectedCellColumn);
-		}
 	};
 
 	/**

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -153,7 +153,6 @@ public class SudokuPlayActivity extends Activity {
 
 		mSudokuBoard.setGame(mSudokuGame);
 		mSudokuGame.setOnPuzzleSolvedListener(onSolvedListener);
-		selectLastChangedCell();
 
 		mHintsQueue.showOneTimeHint("welcome", R.string.welcome, R.string.first_run_hint);
 
@@ -165,6 +164,12 @@ public class SudokuPlayActivity extends Activity {
 		mIMPopup = mIMControlPanel.getInputMethod(IMControlPanel.INPUT_METHOD_POPUP);
 		mIMSingleNumber = mIMControlPanel.getInputMethod(IMControlPanel.INPUT_METHOD_SINGLE_NUMBER);
 		mIMNumpad = mIMControlPanel.getInputMethod(IMControlPanel.INPUT_METHOD_NUMPAD);
+
+        Cell cell = mSudokuGame.getLastChangedCell();
+        if (cell != null)
+            mSudokuBoard.moveCellSelectionTo(cell.getRowIndex(), cell.getColumnIndex());
+        else
+            mSudokuBoard.moveCellSelectionTo(0, 0);
 	}
 
 	@Override
@@ -201,11 +206,15 @@ public class SudokuPlayActivity extends Activity {
 		mIMPopup.setShowNumberTotals(gameSettings.getBoolean("show_number_totals", false));
 		mIMSingleNumber.setHighlightCompletedValues(gameSettings.getBoolean("highlight_completed_values", true));
 		mIMSingleNumber.setShowNumberTotals(gameSettings.getBoolean("show_number_totals", false));
+        mIMSingleNumber.setBidirectionalSelection(gameSettings.getBoolean("bidirectional_selection", true));
+        mIMSingleNumber.setHighlightSimilar(gameSettings.getBoolean("highlight_similar", true));
+        mIMSingleNumber.setmOnSelectedNumberChangedListener(onSelectedNumberChangedListener);
 		mIMNumpad.setHighlightCompletedValues(gameSettings.getBoolean("highlight_completed_values", true));
 		mIMNumpad.setShowNumberTotals(gameSettings.getBoolean("show_number_totals", false));
 
 		mIMControlPanel.activateFirstInputMethod(); // make sure that some input method is activated
 		mIMControlPanelStatePersister.restoreState(mIMControlPanel);
+        mSudokuBoard.invokeOnCellSelected();
 
 		updateTime();
 	}
@@ -462,6 +471,22 @@ public class SudokuPlayActivity extends Activity {
 		}
 
 	};
+
+    public interface OnSelectedNumberChangedListener {
+        void onSelectedNumberChanged(int number);
+    }
+
+	private OnSelectedNumberChangedListener onSelectedNumberChangedListener = new OnSelectedNumberChangedListener() {
+        @Override
+        public void onSelectedNumberChanged(int number) {
+            if (number != 0) {
+                Cell cell = mSudokuGame.getCells().findFirstCell(number);
+                if (cell != null) {
+                    mSudokuBoard.moveCellSelectionTo(cell.getRowIndex(), cell.getColumnIndex());
+                }
+            }
+        }
+    };
 
 	/**
 	 * Update the time of game-play.

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
@@ -25,7 +25,6 @@ import java.util.Map;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.graphics.LightingColorFilter;
 import android.graphics.PorterDuff;
 import android.os.Handler;
 import android.view.LayoutInflater;
@@ -42,6 +41,7 @@ import org.moire.opensudoku.game.SudokuGame;
 import org.moire.opensudoku.game.CellCollection.OnChangeListener;
 import org.moire.opensudoku.gui.HintsQueue;
 import org.moire.opensudoku.gui.SudokuBoardView;
+import org.moire.opensudoku.gui.SudokuPlayActivity;
 import org.moire.opensudoku.gui.inputmethod.IMControlPanelStatePersister.StateBundle;
 
 /**
@@ -57,6 +57,8 @@ public class IMSingleNumber extends InputMethod {
 
 	private boolean mHighlightCompletedValues = true;
 	private boolean mShowNumberTotals = false;
+	private boolean mBidirectionalSelection = true;
+	private boolean mHighlightSimilar = true;
 
 	private int mSelectedNumber = 1;
 	private int mEditMode = MODE_EDIT_VALUE;
@@ -64,6 +66,8 @@ public class IMSingleNumber extends InputMethod {
 	private Handler mGuiHandler;
 	private Map<Integer, Button> mNumberButtons;
 	private ImageButton mSwitchNumNoteButton;
+
+	private SudokuPlayActivity.OnSelectedNumberChangedListener mOnSelectedNumberChangedListener = null;
 
 	public IMSingleNumber() {
 		super();
@@ -91,6 +95,26 @@ public class IMSingleNumber extends InputMethod {
 
 	public void setShowNumberTotals(boolean showNumberTotals) {
 		mShowNumberTotals = showNumberTotals;
+	}
+
+	public boolean getBidirectionalSelection() {
+		return mBidirectionalSelection;
+	}
+
+	public void setBidirectionalSelection(boolean bidirectionalSelection) {
+		mBidirectionalSelection = bidirectionalSelection;
+	}
+
+	public boolean getHighlightSimilar() {
+		return mHighlightSimilar;
+	}
+
+	public void setHighlightSimilar(boolean highlightSimilar) {
+		mHighlightSimilar = highlightSimilar;
+	}
+
+	public void setmOnSelectedNumberChangedListener(SudokuPlayActivity.OnSelectedNumberChangedListener l) {
+		mOnSelectedNumberChangedListener = l;
 	}
 
 	@Override
@@ -158,6 +182,7 @@ public class IMSingleNumber extends InputMethod {
         @Override
         public boolean onTouch(View view, MotionEvent motionEvent) {
             mSelectedNumber = (Integer) view.getTag();
+			onSelectedNumberChanged();
             update();
             return true;
         }
@@ -168,7 +193,7 @@ public class IMSingleNumber extends InputMethod {
 		@Override
 		public void onClick(View v) {
 			mSelectedNumber = (Integer) v.getTag();
-
+			onSelectedNumberChanged();
 			update();
 		}
 	};
@@ -251,6 +276,25 @@ public class IMSingleNumber extends InputMethod {
 	@Override
 	protected void onActivated() {
 		update();
+	}
+
+	@Override
+	protected void onCellSelected(Cell cell) {
+		super.onCellSelected(cell);
+
+		if (mBidirectionalSelection) {
+			int v = cell.getValue();
+			if (v != 0 && v != mSelectedNumber) {
+				mSelectedNumber = cell.getValue();
+				update();
+			}
+		}
+	}
+
+	private void onSelectedNumberChanged() {
+		if (mBidirectionalSelection && mHighlightSimilar && mOnSelectedNumberChangedListener != null) {
+			mOnSelectedNumberChangedListener.onSelectedNumberChanged(mSelectedNumber);
+		}
 	}
 
 	@Override

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
@@ -201,6 +201,7 @@ public class IMSingleNumber extends InputMethod {
 				for (Button b : mNumberButtons.values()) {
 					if (b.getTag().equals(mSelectedNumber)) {
 						b.setTextAppearance(mContext, android.R.style.TextAppearance_Large);
+						b.getBackground().setColorFilter(null);
                         /* Use focus instead color */
 						/*LightingColorFilter selBkgColorFilter = new LightingColorFilter(
 								mContext.getResources().getColor(R.color.im_number_button_selected_background), 0);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -214,4 +214,8 @@
 	<!-- Strings added/changed in 2.3.0 -->
 	<string name="highlight_similar_cells">Highlight similar cells</string>
 	<string name="highlight_similar_cells_summary">Highlight cells with similar values</string>
+
+	<!-- Strings added/changed in 2.4.0 -->
+	<string name="bidirectional_selection">SingleNumber panel mode - Auto selection</string>
+	<string name="bidirectional_selection_summary">A selection of a cell automatically selects a corresponding button of the SN input panel. And vice versa </string>
 </resources>

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -20,6 +20,11 @@
 			android:summary="@string/highlight_similar_cells_summary"
 			android:defaultValue="true"/>
 		<CheckBoxPreference
+			android:key="bidirectional_selection"
+			android:title="@string/bidirectional_selection"
+			android:summary="@string/bidirectional_selection_summary"
+			android:defaultValue="true"/>
+		<CheckBoxPreference
 				android:key="show_number_totals"
 				android:title="@string/show_number_totals"
 				android:summary="@string/show_number_totals_summary"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 23 17:56:45 MSK 2017
+#Sun Oct 29 16:33:23 MSK 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Hello :)
This pull requests contains:
1. Checkpoint issue.
    Now app saves undo history for games which are in "Playing" status. As well as checkpoints.
2. After performing an undo, the previously edited cell will be selected.
3. New option has been added - Bidirectional selection for Single Number input panel. Any selection of a cell will automatically select a corresponding number of the input panel. And vice versa - if user selects a number on input panel, all corresponding cells will be highlighted (in case if option Highlight Similar is also enabled)
4. Fixed a small issue with the congratulation message: "Congratulations, you have solved the puzzle in nn:nn". How to reproduce: solve a puzzle, get a message, restart the puzzle, solve it again,  and get  the same message (with the same time) as the first.
5. Fixed a small issue with SN input panel - selected number stays in "completed" status after a puzzle restart.