### PR TITLE
Added a new version of sudoku data format. Which supports short notes…

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/db/SudokuDatabase.java
+++ b/app/src/main/java/org/moire/opensudoku/db/SudokuDatabase.java
@@ -386,10 +386,8 @@ public class SudokuDatabase {
 			throw new SudokuInvalidFormatException(pars.data);
 		}
 
-		if (!CellCollection.isValid(pars.data, CellCollection.DATA_VERSION_PLAIN)) {
-			if (!CellCollection.isValid(pars.data, CellCollection.DATA_VERSION_1)) {
-				throw new SudokuInvalidFormatException(pars.data);
-			}
+		if (!CellCollection.isValid(pars.data)) {
+			throw new SudokuInvalidFormatException(pars.data);
 		}
 
 		if (mInsertSudokuStatement == null) {

--- a/app/src/main/java/org/moire/opensudoku/game/Cell.java
+++ b/app/src/main/java/org/moire/opensudoku/game/Cell.java
@@ -229,10 +229,10 @@ public class Cell {
 	 * @param data
 	 * @return
 	 */
-	public static Cell deserialize(StringTokenizer data) {
+	public static Cell deserialize(StringTokenizer data, int version) {
 		Cell cell = new Cell();
 		cell.setValue(Integer.parseInt(data.nextToken()));
-		cell.setNote(CellNote.deserialize(data.nextToken()));
+		cell.setNote(CellNote.deserialize(data.nextToken(), version));
 		cell.setEditable(data.nextToken().equals("1"));
 
 		return cell;
@@ -247,7 +247,7 @@ public class Cell {
 	 */
 	public static Cell deserialize(String cellData) {
 		StringTokenizer data = new StringTokenizer(cellData, "|");
-		return deserialize(data);
+		return deserialize(data, CellCollection.DATA_VERSION);
 	}
 
 

--- a/app/src/main/java/org/moire/opensudoku/game/CellNote.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellNote.java
@@ -56,12 +56,31 @@ public class CellNote {
 	 *
 	 * @param note
 	 */
-	public static CellNote deserialize(String note) {
+    public static CellNote deserialize(String note) {
+        return deserialize(note, CellCollection.DATA_VERSION);
+    }
 
-		if (note == null || note.equals("") || note.equals("0"))
-		    return new CellNote((short)0);
+	public static CellNote deserialize(String note, int version) {
 
-        return new CellNote((short)Integer.parseInt(note));
+	    int noteValue = 0;
+		if (note != null && !note.equals("") && !note.equals("-"))
+        {
+            if (version == CellCollection.DATA_VERSION_1) {
+                StringTokenizer tokenizer = new StringTokenizer(note, ",");
+                while (tokenizer.hasMoreTokens()) {
+                    String value = tokenizer.nextToken();
+                    if (!value.equals("-")) {
+                        int number = Integer.parseInt(value);
+                        noteValue |= (1 << number);
+                    }
+                }
+            } else {
+                //CellCollection.DATA_VERSION_2
+                noteValue = Integer.parseInt(note);
+            }
+        }
+
+        return new CellNote((short)noteValue);
 	}
 
 


### PR DESCRIPTION
Bug has been fixed, and now the app works correctly with previously saved games. The issue was in saving cell notes - in previous version it was a list of indexes like "1,2,3,4,".  In the new version - it is a single number. I've added new sudoku data format and now it supports 3 versions: Plaint text, Version1, Version2.
Also have tested the import functionality by using files from the site - works correctly.