### PR TITLE
Theme Preview

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -257,6 +257,27 @@ public class CellCollection {
         }
     }
 
+    /**
+     * Fills in all valid notes for all cells based on the values in each row, column, and sector.
+     * This is a destructive operation in that the existing notes are overwritten.
+     */
+    public void fillInNotes() {
+        for (int r = 0; r < SUDOKU_SIZE; r++) {
+            for (int c = 0; c < SUDOKU_SIZE; c++) {
+                Cell cell = getCell(r, c);
+                cell.setNote(new CellNote());
+
+                CellGroup row = cell.getRow();
+                CellGroup column = cell.getColumn();
+                CellGroup sector = cell.getSector();
+                for (int i = 1; i <= SUDOKU_SIZE; i++) {
+                    if (row.DoesntContain(i) && column.DoesntContain(i) && sector.DoesntContain(i)) {
+                        cell.setNote(cell.getNote().addNumber(i));
+                    }
+                }
+            }
+        }
+    }
 
     /**
      * Returns how many times each value is used in <code>CellCollection</code>.

--- a/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
@@ -49,20 +49,11 @@ public class FillInNotesCommand extends AbstractCellCommand {
         mOldNotes.clear();
         for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
             for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
-                Cell cell = cells.getCell(r, c);
-                mOldNotes.add(new NoteEntry(r, c, cell.getNote()));
-                cell.setNote(new CellNote());
-
-                CellGroup row = cell.getRow();
-                CellGroup column = cell.getColumn();
-                CellGroup sector = cell.getSector();
-                for (int i = 1; i <= CellCollection.SUDOKU_SIZE; i++) {
-                    if (row.DoesntContain(i) && column.DoesntContain(i) && sector.DoesntContain(i)) {
-                        cell.setNote(cell.getNote().addNumber(i));
-                    }
-                }
+                mOldNotes.add(new NoteEntry(r, c, cells.getCell(r, c).getNote()));
             }
         }
+
+        cells.fillInNotes();
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/GameSettingsActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/GameSettingsActivity.java
@@ -25,12 +25,14 @@ import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
+import android.preference.PreferenceGroup;
+import android.preference.PreferenceScreen;
 
 import org.moire.opensudoku.R;
 
 public class GameSettingsActivity extends PreferenceActivity {
 
-    private Preference mScreenCustomTheme;
+    private PreferenceGroup mScreenCustomTheme;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,7 +45,7 @@ public class GameSettingsActivity extends PreferenceActivity {
         ListPreference mTheme = (ListPreference) findPreference("theme");
         mTheme.setOnPreferenceChangeListener(mThemeChanged);
 
-        mScreenCustomTheme = findPreference("screen_custom_theme");
+        mScreenCustomTheme = (PreferenceGroup)findPreference("screen_custom_theme");
         enableScreenCustomTheme(mTheme.getValue());
     }
 

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -205,7 +205,7 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
         CustomThemeListAdapter(SudokuBoardCustomThemePreferenceGroup preferenceGroup) {
             mPreferenceGroup = preferenceGroup;
             mCopyFromExistingThemePreference = new Preference(preferenceGroup.getContext());
-            mCopyFromExistingThemePreference.setTitle("Copy from existing theme...");
+            mCopyFromExistingThemePreference.setTitle(R.string.copy_from_existing_theme);
         }
 
         @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2009 Roman Masek
+ *
+ * This file is part of OpenSudoku.
+ *
+ * OpenSudoku is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenSudoku is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenSudoku.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.moire.opensudoku.gui;
+
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.content.res.TypedArray;
+import android.database.DataSetObserver;
+import android.preference.DialogPreference;
+import android.preference.ListPreference;
+import android.preference.Preference;
+import android.preference.PreferenceGroup;
+import android.preference.PreferenceManager;
+import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ListAdapter;
+import android.widget.ListView;
+
+import net.margaritov.preference.colorpicker.ColorPickerPreference;
+
+import org.moire.opensudoku.R;
+import org.moire.opensudoku.game.CellCollection;
+import org.moire.opensudoku.utils.AndroidUtils;
+
+/**
+ * A {@link Preference} that allows for setting and previewing a custom Sudoku Board theme.
+ */
+public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup implements
+        PreferenceManager.OnActivityDestroyListener,
+        SharedPreferences.OnSharedPreferenceChangeListener {
+    private SudokuBoardView mBoard;
+    private Dialog mDialog;
+    private SharedPreferences mGameSettings = PreferenceManager.getDefaultSharedPreferences(getContext());
+
+    public SudokuBoardCustomThemePreferenceGroup(Context context, AttributeSet attrs) {
+        super(context, attrs, android.R.attr.preferenceScreenStyle);
+        mGameSettings = PreferenceManager.getDefaultSharedPreferences(context);
+    }
+
+    public SudokuBoardCustomThemePreferenceGroup(Context context) {
+        this(context, null);
+    }
+
+    @Override
+    protected boolean isOnSameScreenAsChildren() {
+        return false;
+    }
+
+    @Override
+    protected void onClick() {
+        if (mDialog != null && mDialog.isShowing()) {
+            return;
+        }
+
+        showDialog();
+    }
+
+    private void showDialog() {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        builder.setPositiveButton(R.string.close, null);
+
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        View sudokuPreviewView = inflater.inflate(R.layout.preference_dialog_sudoku_board_theme, null);
+        prepareSudokuPreviewView(sudokuPreviewView);
+        builder.setCustomTitle(sudokuPreviewView);
+
+        ListView listView = new ListView(getContext());
+        listView.setAdapter(new CustomThemeListAdapter(this));
+        listView.setOnItemClickListener((parent, view, position, id) -> { ((ColorPickerPreference)getPreference(position)).onPreferenceClick(null); });
+        builder.setView(listView);
+
+        mGameSettings.registerOnSharedPreferenceChangeListener(this);
+
+        mDialog = builder.create();
+        mDialog.setOnDismissListener((dialog) -> {
+            mDialog = null;
+            mGameSettings.unregisterOnSharedPreferenceChangeListener(this);
+        });
+        mDialog.show();
+    }
+
+    public void onActivityDestroy() {   
+        if (mDialog == null || !mDialog.isShowing()) {
+            return;
+        }
+        
+        mDialog.dismiss();
+    }
+
+    private void prepareSudokuPreviewView(View view) {
+        mBoard = (SudokuBoardView) view.findViewById(R.id.sudoku_board);
+        mBoard.setFocusable(false);
+
+        CellCollection cells = CellCollection.createDebugGame();
+        cells.getCell(0, 0).setValue(1);
+        cells.fillInNotes();
+        mBoard.setCells(cells);
+
+        updateThemePreview();
+    }
+
+    private void updateThemePreview() {
+        mBoard.setLineColor(mGameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
+        mBoard.setSectorLineColor(mGameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
+        mBoard.setTextColor(mGameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
+        mBoard.setTextColorReadOnly(mGameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
+        mBoard.setTextColorNote(mGameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
+        mBoard.setBackgroundColor(mGameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
+        mBoard.setBackgroundColorSecondary(mGameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
+        mBoard.setBackgroundColorReadOnly(mGameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
+        mBoard.setBackgroundColorTouched(mGameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
+        mBoard.setBackgroundColorSelected(mGameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
+        mBoard.setBackgroundColorHighlighted(mGameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+        mBoard.invalidate();
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        updateThemePreview();
+    }
+
+    private class CustomThemeListAdapter extends BaseAdapter implements ListAdapter {
+        private SudokuBoardCustomThemePreferenceGroup mPreferenceGroup;
+
+        CustomThemeListAdapter(SudokuBoardCustomThemePreferenceGroup preferenceGroup) {
+            mPreferenceGroup = preferenceGroup;
+        }
+
+        @Override
+        public boolean areAllItemsEnabled() {
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled(int position) {
+            return true;
+        }
+
+        @Override
+        public int getCount() {
+            return mPreferenceGroup.getPreferenceCount();
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return mPreferenceGroup.getPreference(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            return mPreferenceGroup.getPreference(position).getView(convertView, parent);
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return mPreferenceGroup.getPreferenceCount() == 0;
+        }
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -58,6 +58,7 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
         SharedPreferences.OnSharedPreferenceChangeListener {
     private SudokuBoardView mBoard;
     private Dialog mDialog;
+    private ListView mListView;
     private Dialog mCopyFromExistingThemeDialog;
     private SharedPreferences mGameSettings = PreferenceManager.getDefaultSharedPreferences(getContext());
 
@@ -93,16 +94,17 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
         prepareSudokuPreviewView(sudokuPreviewView);
         builder.setCustomTitle(sudokuPreviewView);
 
-        ListView listView = new ListView(getContext());
-        listView.setAdapter(new CustomThemeListAdapter(this));
-        listView.setOnItemClickListener(this);
-        builder.setView(listView);
+        mListView = new ListView(getContext());
+        mListView.setAdapter(new CustomThemeListAdapter(this));
+        mListView.setOnItemClickListener(this);
+        builder.setView(mListView);
 
         mGameSettings.registerOnSharedPreferenceChangeListener(this);
 
         mDialog = builder.create();
         mDialog.setOnDismissListener((dialog) -> {
             mDialog = null;
+            mListView = null;
             mGameSettings.unregisterOnSharedPreferenceChangeListener(this);
         });
         mDialog.show();
@@ -182,6 +184,9 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         updateThemePreview();
+        if (mListView != null) {
+            mListView.invalidateViews();
+        }
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -25,10 +25,12 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.res.TypedArray;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,7 +43,11 @@ import android.widget.TextView;
 import net.margaritov.preference.colorpicker.ColorPickerPreference;
 
 import org.moire.opensudoku.R;
+import org.moire.opensudoku.utils.AndroidUtils;
 import org.moire.opensudoku.utils.ThemeUtils;
+
+import java.util.Arrays;
+import java.util.Vector;
 
 /**
  * A {@link Preference} that allows for setting and previewing a custom Sudoku Board theme.
@@ -105,7 +111,12 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
     private void showCopyFromExistingThemeDialog() {
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         builder.setTitle(R.string.select_theme);
-        builder.setItems(R.array.theme_names, (dialog, which) -> {
+        builder.setNegativeButton(android.R.string.cancel, null);
+
+        String[] themeNames = getContext().getResources().getStringArray(R.array.theme_names);
+        String[] themeNamesWithoutCustomTheme = Arrays.copyOfRange(themeNames, 0, themeNames.length - 1);
+        builder.setItems(themeNamesWithoutCustomTheme, (dialog, which) -> {
+            copyFromExistingThemeIndex(which);
             mCopyFromExistingThemeDialog.dismiss();
         });
 
@@ -114,6 +125,38 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
             mCopyFromExistingThemeDialog = null;
         });
         mCopyFromExistingThemeDialog.show();
+    }
+
+    private void copyFromExistingThemeIndex(int which) {
+        String theme = getContext().getResources().getStringArray(R.array.theme_codes)[which];
+        ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
+
+        int[] attributes = {
+                R.attr.lineColor,
+                R.attr.sectorLineColor,
+                R.attr.textColor,
+                R.attr.textColorReadOnly,
+                R.attr.textColorNote,
+                R.attr.backgroundColor,
+                R.attr.backgroundColorSecondary,
+                R.attr.backgroundColorReadOnly,
+                R.attr.backgroundColorTouched,
+                R.attr.backgroundColorSelected,
+                R.attr.backgroundColorHighlighted
+        };
+
+        TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
+        ((ColorPickerPreference)getPreference(0)).onColorChanged(themeColors.getColor(0, R.color.default_lineColor));
+        ((ColorPickerPreference)getPreference(1)).onColorChanged(themeColors.getColor(1, R.color.default_sectorLineColor));
+        ((ColorPickerPreference)getPreference(2)).onColorChanged(themeColors.getColor(2, R.color.default_textColor));
+        ((ColorPickerPreference)getPreference(3)).onColorChanged(themeColors.getColor(3, R.color.default_textColorReadOnly));
+        ((ColorPickerPreference)getPreference(4)).onColorChanged(themeColors.getColor(4, R.color.default_textColorNote));
+        ((ColorPickerPreference)getPreference(5)).onColorChanged(themeColors.getColor(5, R.color.default_backgroundColor));
+        ((ColorPickerPreference)getPreference(6)).onColorChanged(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
+        ((ColorPickerPreference)getPreference(7)).onColorChanged(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
+        ((ColorPickerPreference)getPreference(8)).onColorChanged(themeColors.getColor(8, R.color.default_backgroundColorTouched));
+        ((ColorPickerPreference)getPreference(9)).onColorChanged(themeColors.getColor(9, R.color.default_backgroundColorSelected));
+        ((ColorPickerPreference)getPreference(10)).onColorChanged(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
     }
 
     public void onActivityDestroy() {   

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -24,17 +24,11 @@ package org.moire.opensudoku.gui;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.SharedPreferences;
-import android.content.res.TypedArray;
-import android.database.DataSetObserver;
-import android.preference.DialogPreference;
-import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceGroup;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
-import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -45,8 +39,7 @@ import android.widget.ListView;
 import net.margaritov.preference.colorpicker.ColorPickerPreference;
 
 import org.moire.opensudoku.R;
-import org.moire.opensudoku.game.CellCollection;
-import org.moire.opensudoku.utils.AndroidUtils;
+import org.moire.opensudoku.utils.ThemeUtils;
 
 /**
  * A {@link Preference} that allows for setting and previewing a custom Sudoku Board theme.
@@ -115,29 +108,12 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
 
     private void prepareSudokuPreviewView(View view) {
         mBoard = (SudokuBoardView) view.findViewById(R.id.sudoku_board);
-        mBoard.setFocusable(false);
-
-        CellCollection cells = CellCollection.createDebugGame();
-        cells.getCell(0, 0).setValue(1);
-        cells.fillInNotes();
-        mBoard.setCells(cells);
-
+        ThemeUtils.prepareSudokuPreviewView(mBoard);
         updateThemePreview();
     }
 
     private void updateThemePreview() {
-        mBoard.setLineColor(mGameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
-        mBoard.setSectorLineColor(mGameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
-        mBoard.setTextColor(mGameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
-        mBoard.setTextColorReadOnly(mGameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
-        mBoard.setTextColorNote(mGameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
-        mBoard.setBackgroundColor(mGameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
-        mBoard.setBackgroundColorSecondary(mGameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
-        mBoard.setBackgroundColorReadOnly(mGameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
-        mBoard.setBackgroundColorTouched(mGameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
-        mBoard.setBackgroundColorSelected(mGameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
-        mBoard.setBackgroundColorHighlighted(mGameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
-        mBoard.invalidate();
+        ThemeUtils.applyThemeToSudokuBoardViewFromContext("custom", mBoard, getContext());
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardCustomThemePreferenceGroup.java
@@ -35,6 +35,7 @@ import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ListAdapter;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import net.margaritov.preference.colorpicker.ColorPickerPreference;
 
@@ -85,7 +86,13 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
 
         ListView listView = new ListView(getContext());
         listView.setAdapter(new CustomThemeListAdapter(this));
-        listView.setOnItemClickListener((parent, view, position, id) -> { ((ColorPickerPreference)getPreference(position)).onPreferenceClick(null); });
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            if (position == listView.getCount() - 1) {
+                // Show the copy-from-theme dialog...
+            } else {
+                ((ColorPickerPreference) getPreference(position)).onPreferenceClick(null);
+            }
+        });
         builder.setView(listView);
 
         mGameSettings.registerOnSharedPreferenceChangeListener(this);
@@ -123,9 +130,12 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
 
     private class CustomThemeListAdapter extends BaseAdapter implements ListAdapter {
         private SudokuBoardCustomThemePreferenceGroup mPreferenceGroup;
+        private Preference mCopyFromExistingThemePreference;
 
         CustomThemeListAdapter(SudokuBoardCustomThemePreferenceGroup preferenceGroup) {
             mPreferenceGroup = preferenceGroup;
+            mCopyFromExistingThemePreference = new Preference(preferenceGroup.getContext());
+            mCopyFromExistingThemePreference.setTitle("Copy from existing theme...");
         }
 
         @Override
@@ -140,12 +150,12 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
 
         @Override
         public int getCount() {
-            return mPreferenceGroup.getPreferenceCount();
+            return mPreferenceGroup.getPreferenceCount() + 1;
         }
 
         @Override
         public Object getItem(int position) {
-            return mPreferenceGroup.getPreference(position);
+            return (position == getCount() - 1) ? mCopyFromExistingThemePreference : mPreferenceGroup.getPreference(position);
         }
 
         @Override
@@ -155,12 +165,16 @@ public class SudokuBoardCustomThemePreferenceGroup extends PreferenceGroup imple
 
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
-            return mPreferenceGroup.getPreference(position).getView(convertView, parent);
+            Preference preference = ((Preference)getItem(position));
+
+            // we pass convertView as null for the final element to make sure we don't have a color
+            // preview on the final list view item that is used to copy an existing theme
+            return (position == getCount() - 1) ? preference.getView(null, parent) : preference.getView(convertView, parent);
         }
 
         @Override
         public boolean isEmpty() {
-            return mPreferenceGroup.getPreferenceCount() == 0;
+            return false;
         }
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (C) 2009 Roman Masek
+ *
+ * This file is part of OpenSudoku.
+ *
+ * OpenSudoku is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * OpenSudoku is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OpenSudoku.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package org.moire.opensudoku.gui;
+
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.TypedArray;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.preference.DialogPreference;
+import android.preference.Preference;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.TextView;
+
+import org.moire.opensudoku.R;
+
+/**
+ * A {@link Preference} that allows for integer
+ * input.
+ * <p/>
+ * It is a subclass of {@link DialogPreference} and shows the {@link SeekBar}
+ * in a dialog.
+ * <p/>
+ * <code>SeekBarPreference</code> differs slightly from <code>SeekBar</code>:
+ * <code>SeekBar</code> does not allow minimum other than 0. To overcome this, <code>SeekBarPreference</code>
+ * adds mininum field ({@link #getMin()}, {@link #setMin(int)}) and tracks value instead of progress
+ * ({@link #getValue()}, {@link #setValue(int)}).
+ * <p/>
+ */
+public class SudokuBoardThemePreference extends DialogPreference {
+    /**
+     * The edit text shown in the dialog.
+     */
+    private SeekBar mSeekBar;
+    private TextView mValueLabel;
+
+    private int mMin;
+    private int mMax;
+    private int mValue;
+    private String mValueFormat;
+
+    public SudokuBoardThemePreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        setDialogLayoutResource(R.layout.preference_dialog_sudoku_board_theme);
+
+        mSeekBar = new SeekBar(context, attrs);
+        // Give it an ID so it can be saved/restored
+        mSeekBar.setId(R.id.seek_bar);
+        OnSeekBarChangeListener mOnSeekBarChangeListener = new OnSeekBarChangeListener() {
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress,
+                                          boolean fromUser) {
+                updateValueLabel(progress);
+            }
+
+        };
+        mSeekBar.setOnSeekBarChangeListener(mOnSeekBarChangeListener);
+
+        TypedArray a =
+                context.obtainStyledAttributes(attrs, R.styleable.SeekBarPreference);
+        setMin(a.getInt(R.styleable.SeekBarPreference_min, mMin));
+        setMax(a.getInt(R.styleable.SeekBarPreference_max, mMax));
+        setValue(a.getInt(R.styleable.SeekBarPreference_value, mValue));
+        setValueFormat(a.getString(R.styleable.SeekBarPreference_valueFormat));
+
+        a.recycle();
+    }
+
+    public SudokuBoardThemePreference(Context context) {
+        this(context, null);
+    }
+
+    /**
+     * Sets minimal value which can be set by this preference object.
+     *
+     * @param min
+     */
+    public void setMin(int min) {
+        mMin = min;
+        mSeekBar.setMax(mMax - mMin);
+        mSeekBar.setProgress(mMin);
+    }
+
+    /**
+     * Returns minimal value which can be set by this preference object.
+     *
+     * @return
+     */
+    public int getMin() {
+        return mMin;
+    }
+
+    /**
+     * Sets maximal value which can be set by this preference object.
+     *
+     * @param max
+     */
+    public void setMax(int max) {
+        mMax = max;
+        mSeekBar.setMax(mMax - mMin);
+        mSeekBar.setProgress(mMin);
+    }
+
+    /**
+     * Returns maximal value which can be set by this preference object.
+     *
+     * @return
+     */
+    public int getMax() {
+        return mMax;
+    }
+
+    /**
+     * Saves the value to the {@link SharedPreferences}.
+     */
+    public void setValue(int value) {
+        final boolean wasBlocking = shouldDisableDependents();
+
+        if (value > mMax) {
+            mValue = mMax;
+        } else if (value < mMin) {
+            mValue = mMin;
+        } else {
+            mValue = value;
+        }
+
+        persistInt(value);
+
+        final boolean isBlocking = shouldDisableDependents();
+        if (isBlocking != wasBlocking) {
+            notifyDependencyChange(isBlocking);
+        }
+    }
+
+    /**
+     * Gets the value from the {@link SharedPreferences}.
+     *
+     * @return The current preference value.
+     */
+    public int getValue() {
+        return mValue;
+    }
+
+    public void setValueFormat(String valueFormat) {
+        mValueFormat = valueFormat;
+    }
+
+    public String getValueFormat() {
+        return mValueFormat;
+    }
+
+    @Override
+    protected void onBindDialogView(View view) {
+        super.onBindDialogView(view);
+
+        mValueLabel = view.findViewById(R.id.value);
+
+        SeekBar seekBar = mSeekBar;
+        seekBar.setProgress(getValue() - mMin);
+        updateValueLabel(seekBar.getProgress());
+
+
+        ViewParent oldParent = seekBar.getParent();
+        if (oldParent != view) {
+            if (oldParent != null) {
+                ((ViewGroup) oldParent).removeView(seekBar);
+            }
+            onAddSeekBarToDialogView(view, seekBar);
+        }
+    }
+
+    /**
+     * Adds the SeekBar widget of this preference to the dialog's view.
+     *
+     * @param dialogView The dialog view.
+     */
+    protected void onAddSeekBarToDialogView(View dialogView, SeekBar seekBar) {
+        ViewGroup container = dialogView
+                .findViewById(R.id.seek_bar_container);
+        if (container != null) {
+            container.addView(seekBar, ViewGroup.LayoutParams.FILL_PARENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT);
+        }
+    }
+
+    private void updateValueLabel(int progress) {
+        if (mValueLabel != null) {
+            int value = progress + mMin;
+            if (mValueFormat != null && !mValueFormat.equals("")) {
+                mValueLabel.setText(String.format(mValueFormat, value));
+            } else {
+                mValueLabel.setText(String.valueOf(value));
+            }
+        }
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        super.onDialogClosed(positiveResult);
+
+        if (positiveResult) {
+            int progress = mSeekBar.getProgress() + mMin;
+            if (callChangeListener(progress)) {
+                setValue(progress);
+            }
+        }
+    }
+
+    @Override
+    protected Object onGetDefaultValue(TypedArray a, int index) {
+        return a.getString(index);
+    }
+
+    @Override
+    protected void onSetInitialValue(boolean restoreValue, Object defaultValue) {
+        int defValue = mMin;
+        if (defaultValue != null) {
+            defValue = Integer.parseInt(defaultValue.toString());
+        }
+        setValue(restoreValue ? getPersistedInt(mValue) : defValue);
+    }
+
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        final Parcelable superState = super.onSaveInstanceState();
+        if (isPersistent()) {
+            // No need to save instance state since it's persistent
+            return superState;
+        }
+
+        final SavedState myState = new SavedState(superState);
+        myState.value = getValue();
+        return myState;
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            // Didn't save state for us in onSaveInstanceState
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState myState = (SavedState) state;
+        super.onRestoreInstanceState(myState.getSuperState());
+        setValue(myState.value);
+    }
+
+    private static class SavedState extends BaseSavedState {
+        int value;
+
+        public SavedState(Parcel source) {
+            super(source);
+            value = source.readInt();
+        }
+
+        @Override
+        public void writeToParcel(Parcel dest, int flags) {
+            super.writeToParcel(dest, flags);
+            dest.writeInt(value);
+        }
+
+        public SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        public static final Creator<SavedState> CREATOR =
+                new Creator<SavedState>() {
+                    public SavedState createFromParcel(Parcel in) {
+                        return new SavedState(in);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
+    }
+
+}

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -24,7 +24,9 @@ package org.moire.opensudoku.gui;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
+import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.os.Parcel;
@@ -32,6 +34,8 @@ import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,6 +45,7 @@ import android.widget.TextView;
 
 import org.moire.opensudoku.R;
 import org.moire.opensudoku.game.CellCollection;
+import org.moire.opensudoku.utils.AndroidUtils;
 
 /**
  * A {@link Preference} that allows for setting and previewing a Sudoku Board theme.
@@ -50,6 +55,7 @@ public class SudokuBoardThemePreference extends ListPreference {
      * The edit text shown in the dialog.
      */
     private SudokuBoardView mBoard;
+    private int mClickedDialogEntryIndex;
 
     public SudokuBoardThemePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -60,24 +66,31 @@ public class SudokuBoardThemePreference extends ListPreference {
     }
 
     @Override
-    protected void showDialog(Bundle state) {
-        super.showDialog(state);
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        mClickedDialogEntryIndex = findIndexOfValue(getValue());
+        builder.setSingleChoiceItems(getEntries(), mClickedDialogEntryIndex,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        mClickedDialogEntryIndex = which;
+                        SudokuBoardThemePreference.this.applyThemePreview(
+                                getEntryValues()[mClickedDialogEntryIndex].toString());
+                    }
+                });
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
         View sudokuPreviewView = inflater.inflate(R.layout.preference_dialog_sudoku_board_theme, null);
         prepareSudokuPreviewView(sudokuPreviewView);
-
-        AlertDialog dialog = (AlertDialog)getDialog();
-        ListView listView = dialog.getListView();
-        listView.addHeaderView(sudokuPreviewView);
+        builder.setCustomTitle(sudokuPreviewView);
     }
 
     @Override
-    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
-        super.onPrepareDialogBuilder(builder);
-        // Suppress ListPreference's custom dialog builder options to allow for a fully custom view
-        // for the Sudoku theme preference dialog. This allows us to retain the other common
-        // functions that the ListPreference class adds without needing to use the exact list UI.
+    protected void onDialogClosed(boolean positiveResult) {
+        if (positiveResult && mClickedDialogEntryIndex >= 0 && getEntryValues() != null) {
+            String value = getEntryValues()[mClickedDialogEntryIndex].toString();
+            if (callChangeListener(value)) {
+                setValue(value);
+            }
+        }
     }
 
     private void prepareSudokuPreviewView(View view) {
@@ -88,5 +101,25 @@ public class SudokuBoardThemePreference extends ListPreference {
         cells.getCell(0, 0).setValue(1);
         cells.fillInNotes();
         mBoard.setCells(cells);
+    }
+
+    private void applyThemePreview(String theme) {
+        ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
+
+        TypedValue typedValue = new TypedValue();
+        themeWrapper.getTheme().resolveAttribute(R.attr.backgroundColor, typedValue, true);
+        mBoard.setBackgroundColor(typedValue.data);
+
+        /*mBoard.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
+        mBoard.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
+        mBoard.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
+        mBoard.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
+        mBoard.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
+        mBoard.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
+        mBoard.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
+        mBoard.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
+        mBoard.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
+        mBoard.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
+        mBoard.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));*/
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -34,6 +34,7 @@ import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.util.AttributeSet;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
@@ -79,7 +80,7 @@ public class SudokuBoardThemePreference extends ListPreference {
 
         LayoutInflater inflater = LayoutInflater.from(getContext());
         View sudokuPreviewView = inflater.inflate(R.layout.preference_dialog_sudoku_board_theme, null);
-        prepareSudokuPreviewView(sudokuPreviewView);
+        prepareSudokuPreviewView(sudokuPreviewView, getValue());
         builder.setCustomTitle(sudokuPreviewView);
     }
 
@@ -93,7 +94,7 @@ public class SudokuBoardThemePreference extends ListPreference {
         }
     }
 
-    private void prepareSudokuPreviewView(View view) {
+    private void prepareSudokuPreviewView(View view, String initialTheme) {
         mBoard = (SudokuBoardView) view.findViewById(R.id.sudoku_board);
         mBoard.setFocusable(false);
 
@@ -101,25 +102,39 @@ public class SudokuBoardThemePreference extends ListPreference {
         cells.getCell(0, 0).setValue(1);
         cells.fillInNotes();
         mBoard.setCells(cells);
+
+        applyThemePreview(initialTheme);
     }
 
     private void applyThemePreview(String theme) {
         ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
 
-        TypedValue typedValue = new TypedValue();
-        themeWrapper.getTheme().resolveAttribute(R.attr.backgroundColor, typedValue, true);
-        mBoard.setBackgroundColor(typedValue.data);
+        int[] attributes = {
+                R.attr.lineColor,
+                R.attr.sectorLineColor,
+                R.attr.textColor,
+                R.attr.textColorReadOnly,
+                R.attr.textColorNote,
+                R.attr.backgroundColor,
+                R.attr.backgroundColorSecondary,
+                R.attr.backgroundColorReadOnly,
+                R.attr.backgroundColorTouched,
+                R.attr.backgroundColorSelected,
+                R.attr.backgroundColorHighlighted
+        };
 
-        /*mBoard.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
-        mBoard.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
-        mBoard.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
-        mBoard.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
-        mBoard.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
-        mBoard.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
-        mBoard.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
-        mBoard.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
-        mBoard.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
-        mBoard.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
-        mBoard.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));*/
+        TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
+        mBoard.setLineColor(themeColors.getColor(0, R.color.default_lineColor));
+        mBoard.setSectorLineColor(themeColors.getColor(1, R.color.default_sectorLineColor));
+        mBoard.setTextColor(themeColors.getColor(2, R.color.default_textColor));
+        mBoard.setTextColorReadOnly(themeColors.getColor(3, R.color.default_textColorReadOnly));
+        mBoard.setTextColorNote(themeColors.getColor(4, R.color.default_textColorNote));
+        mBoard.setBackgroundColor(themeColors.getColor(5, R.color.default_backgroundColor));
+        mBoard.setBackgroundColorSecondary(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
+        mBoard.setBackgroundColorReadOnly(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
+        mBoard.setBackgroundColorTouched(themeColors.getColor(8, R.color.default_backgroundColorTouched));
+        mBoard.setBackgroundColorSelected(themeColors.getColor(9, R.color.default_backgroundColorSelected));
+        mBoard.setBackgroundColorHighlighted(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
+        mBoard.invalidate();
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -21,293 +21,72 @@
 package org.moire.opensudoku.gui;
 
 
+import android.app.AlertDialog;
+import android.app.Dialog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.TypedArray;
+import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.preference.DialogPreference;
+import android.preference.ListPreference;
 import android.preference.Preference;
 import android.util.AttributeSet;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
+import android.widget.ListView;
 import android.widget.TextView;
 
 import org.moire.opensudoku.R;
+import org.moire.opensudoku.game.CellCollection;
 
 /**
- * A {@link Preference} that allows for integer
- * input.
- * <p/>
- * It is a subclass of {@link DialogPreference} and shows the {@link SeekBar}
- * in a dialog.
- * <p/>
- * <code>SeekBarPreference</code> differs slightly from <code>SeekBar</code>:
- * <code>SeekBar</code> does not allow minimum other than 0. To overcome this, <code>SeekBarPreference</code>
- * adds mininum field ({@link #getMin()}, {@link #setMin(int)}) and tracks value instead of progress
- * ({@link #getValue()}, {@link #setValue(int)}).
- * <p/>
+ * A {@link Preference} that allows for setting and previewing a Sudoku Board theme.
  */
-public class SudokuBoardThemePreference extends DialogPreference {
+public class SudokuBoardThemePreference extends ListPreference {
     /**
      * The edit text shown in the dialog.
      */
-    private SeekBar mSeekBar;
-    private TextView mValueLabel;
-
-    private int mMin;
-    private int mMax;
-    private int mValue;
-    private String mValueFormat;
+    private SudokuBoardView mBoard;
 
     public SudokuBoardThemePreference(Context context, AttributeSet attrs) {
         super(context, attrs);
-
-        setDialogLayoutResource(R.layout.preference_dialog_sudoku_board_theme);
-
-        mSeekBar = new SeekBar(context, attrs);
-        // Give it an ID so it can be saved/restored
-        mSeekBar.setId(R.id.seek_bar);
-        OnSeekBarChangeListener mOnSeekBarChangeListener = new OnSeekBarChangeListener() {
-
-            @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
-            }
-
-            @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
-            }
-
-            @Override
-            public void onProgressChanged(SeekBar seekBar, int progress,
-                                          boolean fromUser) {
-                updateValueLabel(progress);
-            }
-
-        };
-        mSeekBar.setOnSeekBarChangeListener(mOnSeekBarChangeListener);
-
-        TypedArray a =
-                context.obtainStyledAttributes(attrs, R.styleable.SeekBarPreference);
-        setMin(a.getInt(R.styleable.SeekBarPreference_min, mMin));
-        setMax(a.getInt(R.styleable.SeekBarPreference_max, mMax));
-        setValue(a.getInt(R.styleable.SeekBarPreference_value, mValue));
-        setValueFormat(a.getString(R.styleable.SeekBarPreference_valueFormat));
-
-        a.recycle();
     }
 
     public SudokuBoardThemePreference(Context context) {
         this(context, null);
     }
 
-    /**
-     * Sets minimal value which can be set by this preference object.
-     *
-     * @param min
-     */
-    public void setMin(int min) {
-        mMin = min;
-        mSeekBar.setMax(mMax - mMin);
-        mSeekBar.setProgress(mMin);
-    }
+    @Override
+    protected void showDialog(Bundle state) {
+        super.showDialog(state);
 
-    /**
-     * Returns minimal value which can be set by this preference object.
-     *
-     * @return
-     */
-    public int getMin() {
-        return mMin;
-    }
+        LayoutInflater inflater = LayoutInflater.from(getContext());
+        View sudokuPreviewView = inflater.inflate(R.layout.preference_dialog_sudoku_board_theme, null);
+        prepareSudokuPreviewView(sudokuPreviewView);
 
-    /**
-     * Sets maximal value which can be set by this preference object.
-     *
-     * @param max
-     */
-    public void setMax(int max) {
-        mMax = max;
-        mSeekBar.setMax(mMax - mMin);
-        mSeekBar.setProgress(mMin);
-    }
-
-    /**
-     * Returns maximal value which can be set by this preference object.
-     *
-     * @return
-     */
-    public int getMax() {
-        return mMax;
-    }
-
-    /**
-     * Saves the value to the {@link SharedPreferences}.
-     */
-    public void setValue(int value) {
-        final boolean wasBlocking = shouldDisableDependents();
-
-        if (value > mMax) {
-            mValue = mMax;
-        } else if (value < mMin) {
-            mValue = mMin;
-        } else {
-            mValue = value;
-        }
-
-        persistInt(value);
-
-        final boolean isBlocking = shouldDisableDependents();
-        if (isBlocking != wasBlocking) {
-            notifyDependencyChange(isBlocking);
-        }
-    }
-
-    /**
-     * Gets the value from the {@link SharedPreferences}.
-     *
-     * @return The current preference value.
-     */
-    public int getValue() {
-        return mValue;
-    }
-
-    public void setValueFormat(String valueFormat) {
-        mValueFormat = valueFormat;
-    }
-
-    public String getValueFormat() {
-        return mValueFormat;
+        AlertDialog dialog = (AlertDialog)getDialog();
+        ListView listView = dialog.getListView();
+        listView.addHeaderView(sudokuPreviewView);
     }
 
     @Override
-    protected void onBindDialogView(View view) {
-        super.onBindDialogView(view);
-
-        mValueLabel = view.findViewById(R.id.value);
-
-        SeekBar seekBar = mSeekBar;
-        seekBar.setProgress(getValue() - mMin);
-        updateValueLabel(seekBar.getProgress());
-
-
-        ViewParent oldParent = seekBar.getParent();
-        if (oldParent != view) {
-            if (oldParent != null) {
-                ((ViewGroup) oldParent).removeView(seekBar);
-            }
-            onAddSeekBarToDialogView(view, seekBar);
-        }
+    protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
+        super.onPrepareDialogBuilder(builder);
+        // Suppress ListPreference's custom dialog builder options to allow for a fully custom view
+        // for the Sudoku theme preference dialog. This allows us to retain the other common
+        // functions that the ListPreference class adds without needing to use the exact list UI.
     }
 
-    /**
-     * Adds the SeekBar widget of this preference to the dialog's view.
-     *
-     * @param dialogView The dialog view.
-     */
-    protected void onAddSeekBarToDialogView(View dialogView, SeekBar seekBar) {
-        ViewGroup container = dialogView
-                .findViewById(R.id.seek_bar_container);
-        if (container != null) {
-            container.addView(seekBar, ViewGroup.LayoutParams.FILL_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT);
-        }
+    private void prepareSudokuPreviewView(View view) {
+        mBoard = (SudokuBoardView) view.findViewById(R.id.sudoku_board);
+        mBoard.setFocusable(false);
+
+        CellCollection cells = CellCollection.createDebugGame();
+        cells.getCell(0, 0).setValue(1);
+        cells.fillInNotes();
+        mBoard.setCells(cells);
     }
-
-    private void updateValueLabel(int progress) {
-        if (mValueLabel != null) {
-            int value = progress + mMin;
-            if (mValueFormat != null && !mValueFormat.equals("")) {
-                mValueLabel.setText(String.format(mValueFormat, value));
-            } else {
-                mValueLabel.setText(String.valueOf(value));
-            }
-        }
-    }
-
-    @Override
-    protected void onDialogClosed(boolean positiveResult) {
-        super.onDialogClosed(positiveResult);
-
-        if (positiveResult) {
-            int progress = mSeekBar.getProgress() + mMin;
-            if (callChangeListener(progress)) {
-                setValue(progress);
-            }
-        }
-    }
-
-    @Override
-    protected Object onGetDefaultValue(TypedArray a, int index) {
-        return a.getString(index);
-    }
-
-    @Override
-    protected void onSetInitialValue(boolean restoreValue, Object defaultValue) {
-        int defValue = mMin;
-        if (defaultValue != null) {
-            defValue = Integer.parseInt(defaultValue.toString());
-        }
-        setValue(restoreValue ? getPersistedInt(mValue) : defValue);
-    }
-
-    @Override
-    protected Parcelable onSaveInstanceState() {
-        final Parcelable superState = super.onSaveInstanceState();
-        if (isPersistent()) {
-            // No need to save instance state since it's persistent
-            return superState;
-        }
-
-        final SavedState myState = new SavedState(superState);
-        myState.value = getValue();
-        return myState;
-    }
-
-    @Override
-    protected void onRestoreInstanceState(Parcelable state) {
-        if (state == null || !state.getClass().equals(SavedState.class)) {
-            // Didn't save state for us in onSaveInstanceState
-            super.onRestoreInstanceState(state);
-            return;
-        }
-
-        SavedState myState = (SavedState) state;
-        super.onRestoreInstanceState(myState.getSuperState());
-        setValue(myState.value);
-    }
-
-    private static class SavedState extends BaseSavedState {
-        int value;
-
-        public SavedState(Parcel source) {
-            super(source);
-            value = source.readInt();
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-            dest.writeInt(value);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
-        public static final Creator<SavedState> CREATOR =
-                new Creator<SavedState>() {
-                    public SavedState createFromParcel(Parcel in) {
-                        return new SavedState(in);
-                    }
-
-                    public SavedState[] newArray(int size) {
-                        return new SavedState[size];
-                    }
-                };
-    }
-
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -33,6 +33,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.util.Pair;
 import android.util.TypedValue;
@@ -107,34 +108,51 @@ public class SudokuBoardThemePreference extends ListPreference {
     }
 
     private void applyThemePreview(String theme) {
-        ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
 
-        int[] attributes = {
-                R.attr.lineColor,
-                R.attr.sectorLineColor,
-                R.attr.textColor,
-                R.attr.textColorReadOnly,
-                R.attr.textColorNote,
-                R.attr.backgroundColor,
-                R.attr.backgroundColorSecondary,
-                R.attr.backgroundColorReadOnly,
-                R.attr.backgroundColorTouched,
-                R.attr.backgroundColorSelected,
-                R.attr.backgroundColorHighlighted
-        };
+        if (theme.equals("custom")) {
 
-        TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
-        mBoard.setLineColor(themeColors.getColor(0, R.color.default_lineColor));
-        mBoard.setSectorLineColor(themeColors.getColor(1, R.color.default_sectorLineColor));
-        mBoard.setTextColor(themeColors.getColor(2, R.color.default_textColor));
-        mBoard.setTextColorReadOnly(themeColors.getColor(3, R.color.default_textColorReadOnly));
-        mBoard.setTextColorNote(themeColors.getColor(4, R.color.default_textColorNote));
-        mBoard.setBackgroundColor(themeColors.getColor(5, R.color.default_backgroundColor));
-        mBoard.setBackgroundColorSecondary(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
-        mBoard.setBackgroundColorReadOnly(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
-        mBoard.setBackgroundColorTouched(themeColors.getColor(8, R.color.default_backgroundColorTouched));
-        mBoard.setBackgroundColorSelected(themeColors.getColor(9, R.color.default_backgroundColorSelected));
-        mBoard.setBackgroundColorHighlighted(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
+            SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(getContext());
+            mBoard.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
+            mBoard.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
+            mBoard.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
+            mBoard.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
+            mBoard.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
+            mBoard.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
+            mBoard.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
+            mBoard.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
+            mBoard.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
+            mBoard.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
+            mBoard.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+        } else {
+            ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
+
+            int[] attributes = {
+                    R.attr.lineColor,
+                    R.attr.sectorLineColor,
+                    R.attr.textColor,
+                    R.attr.textColorReadOnly,
+                    R.attr.textColorNote,
+                    R.attr.backgroundColor,
+                    R.attr.backgroundColorSecondary,
+                    R.attr.backgroundColorReadOnly,
+                    R.attr.backgroundColorTouched,
+                    R.attr.backgroundColorSelected,
+                    R.attr.backgroundColorHighlighted
+            };
+
+            TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
+            mBoard.setLineColor(themeColors.getColor(0, R.color.default_lineColor));
+            mBoard.setSectorLineColor(themeColors.getColor(1, R.color.default_sectorLineColor));
+            mBoard.setTextColor(themeColors.getColor(2, R.color.default_textColor));
+            mBoard.setTextColorReadOnly(themeColors.getColor(3, R.color.default_textColorReadOnly));
+            mBoard.setTextColorNote(themeColors.getColor(4, R.color.default_textColorNote));
+            mBoard.setBackgroundColor(themeColors.getColor(5, R.color.default_backgroundColor));
+            mBoard.setBackgroundColorSecondary(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
+            mBoard.setBackgroundColorReadOnly(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
+            mBoard.setBackgroundColorTouched(themeColors.getColor(8, R.color.default_backgroundColorTouched));
+            mBoard.setBackgroundColorSelected(themeColors.getColor(9, R.color.default_backgroundColorSelected));
+            mBoard.setBackgroundColorHighlighted(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
+        }
         mBoard.invalidate();
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardThemePreference.java
@@ -22,32 +22,16 @@ package org.moire.opensudoku.gui;
 
 
 import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
-import android.content.res.TypedArray;
-import android.os.Bundle;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.preference.ListPreference;
 import android.preference.Preference;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
-import android.util.Pair;
-import android.util.TypedValue;
-import android.view.ContextThemeWrapper;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
-import android.view.ViewParent;
-import android.widget.ListView;
-import android.widget.TextView;
 
 import org.moire.opensudoku.R;
-import org.moire.opensudoku.game.CellCollection;
-import org.moire.opensudoku.utils.AndroidUtils;
+import org.moire.opensudoku.utils.ThemeUtils;
 
 /**
  * A {@link Preference} that allows for setting and previewing a Sudoku Board theme.
@@ -97,62 +81,11 @@ public class SudokuBoardThemePreference extends ListPreference {
 
     private void prepareSudokuPreviewView(View view, String initialTheme) {
         mBoard = (SudokuBoardView) view.findViewById(R.id.sudoku_board);
-        mBoard.setFocusable(false);
-
-        CellCollection cells = CellCollection.createDebugGame();
-        cells.getCell(0, 0).setValue(1);
-        cells.fillInNotes();
-        mBoard.setCells(cells);
-
+        ThemeUtils.prepareSudokuPreviewView(mBoard);
         applyThemePreview(initialTheme);
     }
 
     private void applyThemePreview(String theme) {
-
-        if (theme.equals("custom")) {
-
-            SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(getContext());
-            mBoard.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
-            mBoard.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
-            mBoard.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
-            mBoard.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
-            mBoard.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
-            mBoard.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
-            mBoard.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
-            mBoard.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
-            mBoard.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
-            mBoard.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
-            mBoard.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
-        } else {
-            ContextThemeWrapper themeWrapper = new ContextThemeWrapper(getContext(), AndroidUtils.getThemeResourceIdFromString(theme));
-
-            int[] attributes = {
-                    R.attr.lineColor,
-                    R.attr.sectorLineColor,
-                    R.attr.textColor,
-                    R.attr.textColorReadOnly,
-                    R.attr.textColorNote,
-                    R.attr.backgroundColor,
-                    R.attr.backgroundColorSecondary,
-                    R.attr.backgroundColorReadOnly,
-                    R.attr.backgroundColorTouched,
-                    R.attr.backgroundColorSelected,
-                    R.attr.backgroundColorHighlighted
-            };
-
-            TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
-            mBoard.setLineColor(themeColors.getColor(0, R.color.default_lineColor));
-            mBoard.setSectorLineColor(themeColors.getColor(1, R.color.default_sectorLineColor));
-            mBoard.setTextColor(themeColors.getColor(2, R.color.default_textColor));
-            mBoard.setTextColorReadOnly(themeColors.getColor(3, R.color.default_textColorReadOnly));
-            mBoard.setTextColorNote(themeColors.getColor(4, R.color.default_textColorNote));
-            mBoard.setBackgroundColor(themeColors.getColor(5, R.color.default_backgroundColor));
-            mBoard.setBackgroundColorSecondary(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
-            mBoard.setBackgroundColorReadOnly(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
-            mBoard.setBackgroundColorTouched(themeColors.getColor(8, R.color.default_backgroundColorTouched));
-            mBoard.setBackgroundColorSelected(themeColors.getColor(9, R.color.default_backgroundColorSelected));
-            mBoard.setBackgroundColorHighlighted(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
-        }
-        mBoard.invalidate();
+        ThemeUtils.applyThemeToSudokuBoardViewFromContext(theme, mBoard, getContext());
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/utils/AndroidUtils.java
+++ b/app/src/main/java/org/moire/opensudoku/utils/AndroidUtils.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
+import android.content.res.Resources;
 import android.preference.PreferenceManager;
 
 import org.moire.opensudoku.R;
@@ -33,38 +34,33 @@ public class AndroidUtils {
         return list.size() > 0;
     }
 
+    public static int getThemeResourceIdFromString(String theme){
+        switch (theme) {
+            case "default":
+                return R.style.Theme_Default;
+            case "paper":
+                return R.style.Theme_Paper;
+            case "graphpaper":
+                return R.style.Theme_GraphPaper;
+            case "light":
+                return R.style.Theme_Light;
+            case "paperlight":
+                return R.style.Theme_PaperLight;
+            case "graphpaperlight":
+                return R.style.Theme_GraphPaperLight;
+            case "highcontrast":
+                return R.style.Theme_HighContrast;
+            case "invertedhighcontrast":
+                return R.style.Theme_InvertedHighContrast;
+            default:
+                return R.style.Theme_Default;
+        }
+    }
+
     public static void setThemeFromPreferences(Context context) {
         SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(context);
         String theme = gameSettings.getString("theme", "default");
-        switch (theme) {
-            case "default":
-                context.setTheme(R.style.Theme_Default);
-                break;
-            case "paper":
-                context.setTheme(R.style.Theme_Paper);
-                break;
-            case "graphpaper":
-                context.setTheme(R.style.Theme_GraphPaper);
-                break;
-            case "light":
-                context.setTheme(R.style.Theme_Light);
-                break;
-            case "paperlight":
-                context.setTheme(R.style.Theme_PaperLight);
-                break;
-            case "graphpaperlight":
-                context.setTheme(R.style.Theme_GraphPaperLight);
-                break;
-            case "highcontrast":
-                context.setTheme(R.style.Theme_HighContrast);
-                break;
-            case "invertedhighcontrast":
-                context.setTheme(R.style.Theme_InvertedHighContrast);
-                break;
-            default:
-                context.setTheme(R.style.Theme_Default);
-                break;
-        }
+        context.setTheme(getThemeResourceIdFromString(theme));
     }
 
     /**

--- a/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
+++ b/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
@@ -1,0 +1,72 @@
+package org.moire.opensudoku.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.TypedArray;
+import android.preference.PreferenceManager;
+import android.view.ContextThemeWrapper;
+import android.view.View;
+
+import org.moire.opensudoku.R;
+import org.moire.opensudoku.game.CellCollection;
+import org.moire.opensudoku.gui.SudokuBoardView;
+
+public class ThemeUtils {
+
+    public static void applyThemeToSudokuBoardViewFromContext(String theme, SudokuBoardView board, Context context) {
+        if (theme.equals("custom")) {
+
+            SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(context);
+            board.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
+            board.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
+            board.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
+            board.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
+            board.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
+            board.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
+            board.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
+            board.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
+            board.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
+            board.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
+            board.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+        } else {
+            ContextThemeWrapper themeWrapper = new ContextThemeWrapper(context, AndroidUtils.getThemeResourceIdFromString(theme));
+
+            int[] attributes = {
+                    R.attr.lineColor,
+                    R.attr.sectorLineColor,
+                    R.attr.textColor,
+                    R.attr.textColorReadOnly,
+                    R.attr.textColorNote,
+                    R.attr.backgroundColor,
+                    R.attr.backgroundColorSecondary,
+                    R.attr.backgroundColorReadOnly,
+                    R.attr.backgroundColorTouched,
+                    R.attr.backgroundColorSelected,
+                    R.attr.backgroundColorHighlighted
+            };
+
+            TypedArray themeColors = themeWrapper.getTheme().obtainStyledAttributes(attributes);
+            board.setLineColor(themeColors.getColor(0, R.color.default_lineColor));
+            board.setSectorLineColor(themeColors.getColor(1, R.color.default_sectorLineColor));
+            board.setTextColor(themeColors.getColor(2, R.color.default_textColor));
+            board.setTextColorReadOnly(themeColors.getColor(3, R.color.default_textColorReadOnly));
+            board.setTextColorNote(themeColors.getColor(4, R.color.default_textColorNote));
+            board.setBackgroundColor(themeColors.getColor(5, R.color.default_backgroundColor));
+            board.setBackgroundColorSecondary(themeColors.getColor(6, R.color.default_backgroundColorSecondary));
+            board.setBackgroundColorReadOnly(themeColors.getColor(7, R.color.default_backgroundColorReadOnly));
+            board.setBackgroundColorTouched(themeColors.getColor(8, R.color.default_backgroundColorTouched));
+            board.setBackgroundColorSelected(themeColors.getColor(9, R.color.default_backgroundColorSelected));
+            board.setBackgroundColorHighlighted(themeColors.getColor(10, R.color.default_backgroundColorHighlighted));
+        }
+        board.invalidate();
+    }
+
+    public static void prepareSudokuPreviewView(SudokuBoardView board) {
+        board.setFocusable(false);
+
+        CellCollection cells = CellCollection.createDebugGame();
+        cells.getCell(0, 0).setValue(1);
+        cells.fillInNotes();
+        board.setCells(cells);
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
+++ b/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
@@ -65,7 +65,7 @@ public class ThemeUtils {
         board.setFocusable(false);
 
         // Create a sample game by starting with the debug game, removing an extra box (sector),
-        // adding in notes, nd filling in the first 3 clues. This provides a sample of an
+        // adding in notes, and filling in the first 3 clues. This provides a sample of an
         // in-progress game that will demonstrate all of the possible scenarios that have different
         // theme colors applied to them.
         CellCollection cells = CellCollection.createDebugGame();
@@ -75,10 +75,13 @@ public class ThemeUtils {
         cells.getCell(1, 5).setValue(0);
         cells.getCell(2, 4).setValue(0);
         cells.getCell(2, 5).setValue(0);
+        cells.markAllCellsAsEditable();
+        cells.markFilledCellsAsNotEditable();
 
         cells.getCell(0, 0).setValue(1);
         cells.getCell(0, 1).setValue(2);
         cells.getCell(0, 2).setValue(3);
+
         cells.fillInNotes();
         board.setCells(cells);
     }

--- a/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
+++ b/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
@@ -64,8 +64,21 @@ public class ThemeUtils {
     public static void prepareSudokuPreviewView(SudokuBoardView board) {
         board.setFocusable(false);
 
+        // Create a sample game by starting with the debug game, removing an extra box (sector),
+        // adding in notes, nd filling in the first 3 clues. This provides a sample of an
+        // in-progress game that will demonstrate all of the possible scenarios that have different
+        // theme colors applied to them.
         CellCollection cells = CellCollection.createDebugGame();
+        cells.getCell(0, 3).setValue(0);
+        cells.getCell(0, 4).setValue(0);
+        cells.getCell(1, 3).setValue(0);
+        cells.getCell(1, 5).setValue(0);
+        cells.getCell(2, 4).setValue(0);
+        cells.getCell(2, 5).setValue(0);
+
         cells.getCell(0, 0).setValue(1);
+        cells.getCell(0, 1).setValue(2);
+        cells.getCell(0, 2).setValue(3);
         cells.fillInNotes();
         board.setCells(cells);
     }

--- a/app/src/main/res/layout/preference_dialog_sudoku_board_theme.xml
+++ b/app/src/main/res/layout/preference_dialog_sudoku_board_theme.xml
@@ -1,24 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/seek_bar_container"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:padding="16dp">
 
-    <TextView
-        android:id="@+id/value"
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="6dp"
-        android:text="SeekText" />
-
     <org.moire.opensudoku.gui.SudokuBoardView
         android:id="@+id/sudoku_board"
-        android:layout_width="200sp"
-        android:layout_height="200sp"
         android:layout_marginEnd="6dp"
-        android:layout_marginRight="6dp" />
+        android:layout_marginRight="6dp"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:keepScreenOn="true"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/preference_dialog_sudoku_board_theme.xml
+++ b/app/src/main/res/layout/preference_dialog_sudoku_board_theme.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/seek_bar_container"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/value"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="6dp"
+        android:text="SeekText" />
+
+    <org.moire.opensudoku.gui.SudokuBoardView
+        android:id="@+id/sudoku_board"
+        android:layout_width="200sp"
+        android:layout_height="200sp"
+        android:layout_marginEnd="6dp"
+        android:layout_marginRight="6dp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,4 +323,6 @@
 
     <string name="check_solvabitily">Check Solvability</string>
     <string name="puzzle_solvable">This puzzle has a solution.</string>
+
+    <string name="copy_from_existing_theme">Copy from existing theme...</string>
 </resources>

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -80,6 +80,15 @@
             android:key="theme"
             android:summary="@string/theme_summary"
             android:title="@string/theme" />
+        <org.moire.opensudoku.gui.SudokuBoardThemePreference
+            android:defaultValue="0"
+            android:dialogTitle="@string/select_theme"
+            android:key="theme_2"
+            android:summary="@string/theme_summary"
+            android:title="@string/theme"
+            os:max="30"
+            os:min="0"
+            os:valueFormat="%s pixels" />
         <PreferenceScreen
             android:key="screen_custom_theme"
             android:summary="@string/screen_custom_theme_summary"

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -72,7 +72,7 @@
             android:key="show_hints"
             android:summary="@string/show_hints_summary"
             android:title="@string/show_hints" />
-        <ListPreference
+        <!-- <ListPreference
             android:defaultValue="default"
             android:dialogTitle="@string/select_theme"
             android:entries="@array/theme_names"
@@ -80,15 +80,15 @@
             android:key="theme"
             android:summary="@string/theme_summary"
             android:title="@string/theme" />
+        -->
         <org.moire.opensudoku.gui.SudokuBoardThemePreference
-            android:defaultValue="0"
+            android:defaultValue="default"
             android:dialogTitle="@string/select_theme"
-            android:key="theme_2"
+            android:entries="@array/theme_names"
+            android:entryValues="@array/theme_codes"
+            android:key="theme"
             android:summary="@string/theme_summary"
-            android:title="@string/theme"
-            os:max="30"
-            os:min="0"
-            os:valueFormat="%s pixels" />
+            android:title="@string/theme"/>
         <PreferenceScreen
             android:key="screen_custom_theme"
             android:summary="@string/screen_custom_theme_summary"

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -80,9 +80,8 @@
             android:key="theme"
             android:summary="@string/theme_summary"
             android:title="@string/theme"/>
-        <PreferenceScreen
+        <org.moire.opensudoku.gui.SudokuBoardCustomThemePreferenceGroup
             android:key="screen_custom_theme"
-            android:summary="@string/screen_custom_theme_summary"
             android:title="@string/screen_custom_theme">
             <net.margaritov.preference.colorpicker.ColorPickerPreference
                 alphaSlider="true"
@@ -150,7 +149,7 @@
                 android:key="custom_theme_backgroundColorHighlighted"
                 android:summary="@string/default_backgroundColorHighlighted_summary"
                 android:title="@string/default_backgroundColorHighlighted" />
-        </PreferenceScreen>
+        </org.moire.opensudoku.gui.SudokuBoardCustomThemePreferenceGroup>
         <PreferenceScreen
             android:key="screen_game_advanced"
             android:title="@string/more_settings">

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -72,15 +72,6 @@
             android:key="show_hints"
             android:summary="@string/show_hints_summary"
             android:title="@string/show_hints" />
-        <!-- <ListPreference
-            android:defaultValue="default"
-            android:dialogTitle="@string/select_theme"
-            android:entries="@array/theme_names"
-            android:entryValues="@array/theme_codes"
-            android:key="theme"
-            android:summary="@string/theme_summary"
-            android:title="@string/theme" />
-        -->
         <org.moire.opensudoku.gui.SudokuBoardThemePreference
             android:defaultValue="default"
             android:dialogTitle="@string/select_theme"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
This PR adds support to preview the theme for the Sudoku board when selecting a theme or when customizing the theme colors. 

`SudokuBoardThemePreference`
----
![Theme Preview Dialog](https://i.imgur.com/p9o81al.gif)
The `SudokuBoardThemePreference` class is a custom preference that extends ListPreference and adds a Sudoku board view on top of the list of themes to allow the player to see the theme changes in-line before deciding to commit to a new theme. This dialog also supports cancelation (and the theme won't be applied).

`SudokuBoardCustomThemePreferenceGroup`
----
![Custom Theme Preview Dialog](https://i.imgur.com/M7tbh2Z.gif)
The `SudokuBoardCustomThemePreferenceGroup` class is a custom preference group to hold the ColorPickerPreferences that control the custom theme colors. This dialog is almost identical to the theme picker dialog, but because the UI is managed by preference objects, the underlying implementation is quite different. To reuse as much of the existing logic as possible, this class is implemented as a PreferenceGroup and simulates what the PreferenceScreen class does, but with some customized dialog elements.

Additional changes
----
- A `ThemeUtils` class to hold the common theme functions shared across the two new theme preference dialogs.
- Moved the fill-in-notes functionality into the `CellCollection` class so it can be reused elsewhere.

Scenarios Tested
----
On the emulator and physical device:
- Verified switching between various themes in the theme dialog.
- Verified choosing new theme colors in the custom theme dialog.
- Verified view updates correctly when theme or colors change.
- Verified opening and interacting with the main Sudoku activity.
- Verified the settings menu in two languages (no translations, just checking for bugs).