### PR TITLE
Keep same values highlighted after empty cell selection

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuBoardView.java
@@ -59,6 +59,7 @@ public class SudokuBoardView extends View {
     private Cell mTouchedCell;
     // TODO: should I synchronize access to mSelectedCell?
     private Cell mSelectedCell;
+    private int mHighlightedValue = 0;
     private boolean mReadonly = false;
     private boolean mHighlightWrongVals = true;
     private boolean mHighlightTouchedCell = true;
@@ -288,6 +289,14 @@ public class SudokuBoardView extends View {
         return mHighlightSimilarCells;
     }
 
+    public void setHighlightedValue(int value) {
+        mHighlightedValue = value;
+    }
+
+    public int getHighlightedValue() {
+        return mHighlightedValue;
+    }
+
     /**
      * Registers callback which will be invoked when user taps the cell.
      *
@@ -442,8 +451,8 @@ public class SudokuBoardView extends View {
             float noteWidth = mCellWidth / 3f;
 
             int selectedValue = 0;
-            if (mHighlightSimilarCells && mSelectedCell != null) {
-                selectedValue = mSelectedCell.getValue();
+            if (mHighlightSimilarCells && mHighlightedValue > 0) {
+                selectedValue = mHighlightedValue;
             }
 
             for (int row = 0; row < 9; row++) {

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -569,6 +569,7 @@ public class SudokuPlayActivity extends AppCompatActivity {
         public void onSelectedNumberChanged(int number) {
             if (number != 0) {
                 Cell cell = mSudokuGame.getCells().findFirstCell(number);
+                mSudokuBoard.setHighlightedValue(number);
                 if (cell != null) {
                     mSudokuBoard.moveCellSelectionTo(cell.getRowIndex(), cell.getColumnIndex());
                 }

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMNumpad.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMNumpad.java
@@ -152,6 +152,14 @@ public class IMNumpad extends InputMethod {
 
     @Override
     protected void onCellSelected(Cell cell) {
+        if (cell != null) {
+            if (cell.getValue() == mBoard.getHighlightedValue()) {
+                mBoard.setHighlightedValue(0);
+            } else if (cell.getValue() > 0) {
+                mBoard.setHighlightedValue(cell.getValue());
+            }
+        }
+
         mSelectedCell = cell;
     }
 
@@ -174,6 +182,7 @@ public class IMNumpad extends InputMethod {
                     case MODE_EDIT_VALUE:
                         if (selNumber >= 0 && selNumber <= 9) {
                             mGame.setCellValue(selCell, selNumber);
+                            mBoard.setHighlightedValue(selNumber);
                             if (isMoveCellSelectionOnPress()) {
                                 mBoard.moveCellSelectionRight();
                             }

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMPopup.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMPopup.java
@@ -118,6 +118,19 @@ public class IMPopup extends InputMethod {
     }
 
     @Override
+    protected void onCellSelected(Cell cell) {
+        super.onCellSelected(cell);
+
+        if (cell != null) {
+            if (cell.getValue() == mBoard.getHighlightedValue()) {
+                mBoard.setHighlightedValue(0);
+            } else if (cell.getValue() > 0) {
+                mBoard.setHighlightedValue(cell.getValue());
+            }
+        }
+    }
+
+    @Override
     protected void onPause() {
         // release dialog resource (otherwise WindowLeaked exception is logged)
         if (mEditCellDialog != null) {
@@ -154,6 +167,7 @@ public class IMPopup extends InputMethod {
         public boolean onNumberEdit(int number) {
             if (number != -1 && mSelectedCell != null) {
                 mGame.setCellValue(mSelectedCell, number);
+                mBoard.setHighlightedValue(number);
             }
             return true;
         }

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
@@ -253,6 +253,8 @@ public class IMSingleNumber extends InputMethod {
                         b.setText("" + entry.getKey());
                 }
             }
+
+            mBoard.setHighlightedValue(mSelectedNumber);
         }, 100);
     }
 
@@ -272,11 +274,14 @@ public class IMSingleNumber extends InputMethod {
                 update();
             }
         }
+
+        mBoard.setHighlightedValue(mSelectedNumber);
     }
 
     private void onSelectedNumberChanged() {
         if (mBidirectionalSelection && mHighlightSimilar && mOnSelectedNumberChangedListener != null) {
             mOnSelectedNumberChangedListener.onSelectedNumberChanged(mSelectedNumber);
+            mBoard.setHighlightedValue(mSelectedNumber);
         }
     }
 


### PR DESCRIPTION
Currently, when you select any cell, the highlighted value changes to the value in that cell. The changing of the highlighted value clears when you select an empty cell, this can be a hindrance when you are trying to fill in all of the cells for one number.

Cell highlighting is now separate from the selected cell variable.

These changes make it so that if you...
- Select a cell that contains a value, cells with that value will be highlighted
- Select a cell that does not contain a value, the highlighted values will not change
- Select a cell that contains the value that is already highlighted, no cells are highlighted