### PR TITLE
Highlight Notes

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/game/CellNote.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellNote.java
@@ -172,6 +172,14 @@ public class CellNote {
         return new CellNote((short) (mNotedNumbers & ~(1 << (number - 1))));
     }
 
+    public boolean hasNumber(int number) {
+        if (number < 1 || number > 9) {
+            return false;
+        }
+
+        return (mNotedNumbers & (1 << (number - 1))) != 0;
+    }
+
     public CellNote clear() {
         return new CellNote();
     }

--- a/app/src/main/java/org/moire/opensudoku/gui/GameSettingsActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/GameSettingsActivity.java
@@ -21,10 +21,13 @@
 package org.moire.opensudoku.gui;
 
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceGroup;
+import android.preference.PreferenceScreen;
+import android.preference.SwitchPreference;
 
 import org.moire.opensudoku.R;
 import org.moire.opensudoku.utils.ThemeUtils;
@@ -33,6 +36,7 @@ public class GameSettingsActivity extends PreferenceActivity {
 
     private PreferenceGroup mScreenCustomTheme;
     private long mTimestampWhenApplyingTheme;
+    private SwitchPreference mHighlightSimilarNotesPreference;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -49,6 +53,11 @@ public class GameSettingsActivity extends PreferenceActivity {
         mScreenCustomTheme = (PreferenceGroup)findPreference("screen_custom_theme");
         enableScreenCustomTheme(themePreference.getValue());
         mScreenCustomTheme.setOnPreferenceChangeListener((preference, newValue) -> { recreate(); return true; });
+
+        mHighlightSimilarNotesPreference = (SwitchPreference)findPreference("highlight_similar_notes");
+        CheckBoxPreference highlightSimilarCellsPreference = (CheckBoxPreference)findPreference("highlight_similar_cells");
+        highlightSimilarCellsPreference.setOnPreferenceChangeListener(mHighlightSimilarCellsChanged);
+        mHighlightSimilarNotesPreference.setEnabled(highlightSimilarCellsPreference.isChecked());
     }
 
     @Override
@@ -67,6 +76,16 @@ public class GameSettingsActivity extends PreferenceActivity {
         if (newVal) {
             hm.resetOneTimeHints();
         }
+        return true;
+    };
+
+    private OnPreferenceChangeListener mThemeChanged = (preference, newValue) -> {
+        enableScreenCustomTheme((String) newValue);
+        return true;
+    };
+
+    private OnPreferenceChangeListener mHighlightSimilarCellsChanged = (preference, newValue) -> {
+        mHighlightSimilarNotesPreference.setEnabled((Boolean)newValue);
         return true;
     };
 

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -205,7 +205,16 @@ public class SudokuPlayActivity extends ThemedActivity {
 
         mSudokuBoard.setHighlightWrongVals(gameSettings.getBoolean("highlight_wrong_values", true));
         mSudokuBoard.setHighlightTouchedCell(gameSettings.getBoolean("highlight_touched_cell", true));
-        mSudokuBoard.setHighlightSimilarCell(gameSettings.getBoolean("highlight_similar_cells", true));
+
+        boolean highlightSimilarCells = gameSettings.getBoolean("highlight_similar_cells", true);
+        boolean highlightSimilarNotes = gameSettings.getBoolean("highlight_similar_notes", true);
+        if (highlightSimilarCells) {
+            mSudokuBoard.setHighlightSimilarCell(highlightSimilarNotes ?
+                    SudokuBoardView.HighlightMode.NUMBERS_AND_NOTES :
+                    SudokuBoardView.HighlightMode.NUMBERS);
+        } else {
+            mSudokuBoard.setHighlightSimilarCell(SudokuBoardView.HighlightMode.NONE);
+        }
 
         mShowTime = gameSettings.getBoolean("show_time", true);
         if (mSudokuGame.getState() == SudokuGame.GAME_STATE_PLAYING) {

--- a/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/inputmethod/IMSingleNumber.java
@@ -282,7 +282,12 @@ public class IMSingleNumber extends InputMethod {
                 if (selNumber == 0) {
                     mGame.setCellNote(cell, CellNote.EMPTY);
                 } else if (selNumber > 0 && selNumber <= 9) {
-                    mGame.setCellNote(cell, cell.getNote().toggleNumber(selNumber));
+                    CellNote newNote = cell.getNote().toggleNumber(selNumber);
+                    mGame.setCellNote(cell, newNote);
+                    // if we toggled the note off we want to de-select the cell
+                    if (!newNote.hasNumber(selNumber)) {
+                        mBoard.clearCellSelection();
+                    }
                 }
                 break;
             case MODE_EDIT_VALUE:
@@ -293,11 +298,13 @@ public class IMSingleNumber extends InputMethod {
                         // with this number can be deleted by repeated touch
                         if (selNumber == cell.getValue()) {
                             mGame.setCellValue(cell, 0);
+                            mBoard.clearCellSelection();
                         }
                     } else {
                         // Normal flow, just set the value (or clear it if it is repeated touch)
                         if (selNumber == cell.getValue()) {
                             selNumber = 0;
+                            mBoard.clearCellSelection();
                         }
                         mGame.setCellValue(cell, selNumber);
                     }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -5,7 +5,7 @@
     <color name="coffee_colorPrimaryDark">@color/brown_100</color>
     <color name="coffee_colorAccent">@color/brown_600</color>
 
-    <color name="opensudoku_colorPrimaryLight">#B1DDD9</color>
+    <color name="opensudoku_colorPrimaryLight">#D1FDF9</color>
     <color name="opensudoku_colorPrimary">#49B7AC</color>
     <color name="opensudoku_colorPrimaryDark">#009587</color>
     <color name="opensudoku_colorAccent">#656565</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -352,4 +352,6 @@
     <string name="app_color_accent_title">App Accent Color</string>
     <string name="app_color_button_summary">This color is used for button UI controls.</string>
     <string name="app_color_button_title">App Button Color</string>
+    
+    <string name="highlight_similar_notes">Highlight similar notes</string>
 </resources>

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -17,6 +17,10 @@
             android:key="highlight_similar_cells"
             android:summary="@string/highlight_similar_cells_summary"
             android:title="@string/highlight_similar_cells" />
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="highlight_similar_notes"
+            android:title="@string/highlight_similar_notes" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="bidirectional_selection"


### PR DESCRIPTION
This PR adds support for highlighting all notes that match a particular number when a cell is selected. This also includes a new setting to turn off this behavior if desired.

Highlighting note values is particularly important for more complex Sudoku games where figuring out what notes to remove is a large part of the game. This process can be greatly helped by visualizing the patterns the notes make.

Testing
====
- Verified selecting different cell values on each of the input methods highlights the correct notes.
- Verified selecting different cell values with note highlighting turned off.
- Verified selecting different cell values with no highlighting at all.