### PR TITLE
Undo to before mistake

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -254,6 +254,10 @@ public class SudokuGame {
         return mCommandStack.hasCheckpoint();
     }
 
+    public void undoToBeforeMistake() {
+        mCommandStack.undoToSolvableState();
+    }
+
     @Nullable
     public Cell getLastChangedCell() {
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
@@ -1,7 +1,10 @@
 package org.moire.opensudoku.game.command;
 
+import org.moire.opensudoku.game.Cell;
 import org.moire.opensudoku.game.CellCollection;
+import org.moire.opensudoku.game.SudokuSolver;
 
+import java.util.ArrayList;
 import java.util.ListIterator;
 import java.util.Stack;
 import java.util.StringTokenizer;
@@ -97,6 +100,32 @@ public class CommandStack {
         validateCells();
     }
 
+    private boolean hasMistakes(ArrayList<int[]> finalValues) {
+        for (int[] rowColVal : finalValues) {
+            int row = rowColVal[0];
+            int col = rowColVal[1];
+            int val = rowColVal[2];
+            Cell cell = mCells.getCell(row, col);
+
+            if (cell.getValue() != val && cell.getValue() != 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void undoToSolvableState() {
+        SudokuSolver solver = new SudokuSolver();
+        solver.setPuzzle(mCells);
+        ArrayList<int[]> finalValues = solver.solve();
+
+        while (!mCommandStack.empty() && hasMistakes(finalValues)) {
+            mCommandStack.pop().undo();
+        }
+
+        validateCells();
+    }
 
     public boolean hasSomethingToUndo() {
         return mCommandStack.size() != 0;

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -69,18 +69,20 @@ public class SudokuPlayActivity extends ThemedActivity {
 
     public static final int MENU_ITEM_SET_CHECKPOINT = Menu.FIRST + 8;
     public static final int MENU_ITEM_UNDO_TO_CHECKPOINT = Menu.FIRST + 9;
-    public static final int MENU_ITEM_SOLVE = Menu.FIRST + 10;
-    public static final int MENU_ITEM_HINT = Menu.FIRST + 11;
+    public static final int MENU_ITEM_UNDO_TO_BEFORE_MISTAKE = Menu.FIRST + 10;
+    public static final int MENU_ITEM_SOLVE = Menu.FIRST + 11;
+    public static final int MENU_ITEM_HINT = Menu.FIRST + 12;
 
     private static final int DIALOG_RESTART = 1;
     private static final int DIALOG_WELL_DONE = 2;
     private static final int DIALOG_CLEAR_NOTES = 3;
     private static final int DIALOG_UNDO_TO_CHECKPOINT = 4;
-    private static final int DIALOG_SOLVE_PUZZLE = 5;
-    private static final int DIALOG_USED_SOLVER = 6;
-    private static final int DIALOG_PUZZLE_NOT_SOLVED = 7;
-    private static final int DIALOG_HINT = 8;
-    private static final int DIALOG_CANNOT_GIVE_HINT = 9;
+    private static final int DIALOG_UNDO_TO_BEFORE_MISTAKE = 5;
+    private static final int DIALOG_SOLVE_PUZZLE = 6;
+    private static final int DIALOG_USED_SOLVER = 7;
+    private static final int DIALOG_PUZZLE_NOT_SOLVED = 8;
+    private static final int DIALOG_HINT = 9;
+    private static final int DIALOG_CANNOT_GIVE_HINT = 10;
 
     private static final int REQUEST_SETTINGS = 1;
 
@@ -334,6 +336,7 @@ public class SudokuPlayActivity extends ThemedActivity {
 
         menu.add(0, MENU_ITEM_SET_CHECKPOINT, 3, R.string.set_checkpoint);
         menu.add(0, MENU_ITEM_UNDO_TO_CHECKPOINT, 4, R.string.undo_to_checkpoint);
+        menu.add(0, MENU_ITEM_UNDO_TO_BEFORE_MISTAKE, 4, getString(R.string.undo_to_before_mistake));
 
         menu.add(0, MENU_ITEM_HINT, 5, R.string.solver_hint);
         menu.add(0, MENU_ITEM_SOLVE, 6, R.string.solve_puzzle);
@@ -430,6 +433,9 @@ public class SudokuPlayActivity extends ThemedActivity {
             case MENU_ITEM_UNDO_TO_CHECKPOINT:
                 showDialog(DIALOG_UNDO_TO_CHECKPOINT);
                 return true;
+            case MENU_ITEM_UNDO_TO_BEFORE_MISTAKE:
+                showDialog(DIALOG_UNDO_TO_BEFORE_MISTAKE);
+                return true;
             case MENU_ITEM_SOLVE:
                 showDialog(DIALOG_SOLVE_PUZZLE);
                 return true;
@@ -504,6 +510,17 @@ public class SudokuPlayActivity extends ThemedActivity {
                         .setMessage(R.string.undo_to_checkpoint_confirm)
                         .setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
                             mSudokuGame.undoToCheckpoint();
+                            selectLastChangedCell();
+                        })
+                        .setNegativeButton(android.R.string.no, null)
+                        .create();
+            case DIALOG_UNDO_TO_BEFORE_MISTAKE:
+                return new AlertDialog.Builder(this)
+                        .setIcon(R.drawable.ic_undo)
+                        .setTitle(R.string.app_name)
+                        .setMessage(getString(R.string.undo_to_before_mistake_confirm))
+                        .setPositiveButton(android.R.string.yes, (dialog, whichButton) -> {
+                            mSudokuGame.undoToBeforeMistake();
                             selectLastChangedCell();
                         })
                         .setNegativeButton(android.R.string.no, null)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -358,4 +358,6 @@
 
     <string name="resume">Resume</string>
     <string name="sudoku_lists">Sudoku Lists</string>
+    <string name="undo_to_before_mistake">Undo to before mistake</string>
+    <string name="undo_to_before_mistake_confirm">Are you sure you want to undo all actions since the last solvable state?</string>
 </resources>


### PR DESCRIPTION
This PR adds a new feature to undo all progress since the game was in a solvable state -- that is, before any mistakes were made. This is in response to issue #43. This can be used if you realize you made a mistake but don't want to restart the whole puzzle.

This is implemented by first solving the puzzle, then undoing each action one-by-one, checking each step if there are any numbers entered that don't match the solved state.

Scenarios Tested
====
- Verified undoing to known good state after entering an incorrect number.
- Verified undoing to before a mistake when there is no mistake does not change the board.
- Verified undoing to before a mistake does not restart the puzzle but keeps the in-progress state (notes are still present, existing numbers are still present).