### PR TITLE
Remove notes on number entry

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -279,14 +279,18 @@ public class CellCollection {
         }
     }
 
-    public void removeNotesForChangedCell(Cell cell, int mValue) {
+    public void removeNotesForChangedCell(Cell cell, int number) {
+        if (number < 1 || number> 9) {
+            return;
+        }
+
         CellGroup row = cell.getRow();
         CellGroup column = cell.getColumn();
         CellGroup sector = cell.getSector();
         for (int i = 0; i < SUDOKU_SIZE; i++) {
-            row.getCells()[i].setNote(row.getCells()[i].getNote().removeNumber(mValue));
-            column.getCells()[i].setNote(column.getCells()[i].getNote().removeNumber(mValue));
-            sector.getCells()[i].setNote(sector.getCells()[i].getNote().removeNumber(mValue));
+            row.getCells()[i].setNote(row.getCells()[i].getNote().removeNumber(number));
+            column.getCells()[i].setNote(column.getCells()[i].getNote().removeNumber(number));
+            sector.getCells()[i].setNote(sector.getCells()[i].getNote().removeNumber(number));
         }
     }
 

--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -279,6 +279,17 @@ public class CellCollection {
         }
     }
 
+    public void removeNotesForChangedCell(Cell cell, int mValue) {
+        CellGroup row = cell.getRow();
+        CellGroup column = cell.getColumn();
+        CellGroup sector = cell.getSector();
+        for (int i = 0; i < SUDOKU_SIZE; i++) {
+            row.getCells()[i].setNote(row.getCells()[i].getNote().removeNumber(mValue));
+            column.getCells()[i].setNote(column.getCells()[i].getNote().removeNumber(mValue));
+            sector.getCells()[i].setNote(sector.getCells()[i].getNote().removeNumber(mValue));
+        }
+    }
+
     /**
      * Returns how many times each value is used in <code>CellCollection</code>.
      * Returns map with entry for each value.

--- a/app/src/main/java/org/moire/opensudoku/game/CellGroup.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellGroup.java
@@ -78,4 +78,8 @@ public class CellGroup {
         }
         return true;
     }
+
+    public Cell[] getCells() {
+        return mCells;
+    }
 }

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -33,6 +33,7 @@ import org.moire.opensudoku.game.command.ClearAllNotesCommand;
 import org.moire.opensudoku.game.command.CommandStack;
 import org.moire.opensudoku.game.command.EditCellNoteCommand;
 import org.moire.opensudoku.game.command.FillInNotesCommand;
+import org.moire.opensudoku.game.command.SetCellValueAndRemoveNotesCommand;
 import org.moire.opensudoku.game.command.SetCellValueCommand;
 
 public class SudokuGame {
@@ -196,7 +197,8 @@ public class SudokuGame {
         }
 
         if (cell.isEditable()) {
-            executeCommand(new SetCellValueCommand(cell, value));
+            //executeCommand(new SetCellValueCommand(cell, value));
+            executeCommand(new SetCellValueAndRemoveNotesCommand(cell, value));
 
             validate();
             if (isCompleted()) {

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -28,7 +28,6 @@ import androidx.annotation.Nullable;
 import java.util.ArrayList;
 
 import org.moire.opensudoku.game.command.AbstractCommand;
-import org.moire.opensudoku.game.command.AbstractSingleCellCommand;
 import org.moire.opensudoku.game.command.ClearAllNotesCommand;
 import org.moire.opensudoku.game.command.CommandStack;
 import org.moire.opensudoku.game.command.EditCellNoteCommand;
@@ -51,6 +50,7 @@ public class SudokuGame {
     private CellCollection mCells;
     private SudokuSolver mSolver;
     private boolean mUsedSolver = false;
+    private boolean mRemoveNotesOnEntry = false;
 
     private OnPuzzleSolvedListener mOnPuzzleSolvedListener;
     private CommandStack mCommandStack;
@@ -182,6 +182,10 @@ public class SudokuGame {
         return mCommandStack;
     }
 
+    public void setRemoveNotesOnEntry(boolean removeNotesOnEntry) {
+        mRemoveNotesOnEntry = removeNotesOnEntry;
+    }
+
     /**
      * Sets value for the given cell. 0 means empty cell.
      *
@@ -197,8 +201,11 @@ public class SudokuGame {
         }
 
         if (cell.isEditable()) {
-            //executeCommand(new SetCellValueCommand(cell, value));
-            executeCommand(new SetCellValueAndRemoveNotesCommand(cell, value));
+            if (mRemoveNotesOnEntry) {
+                executeCommand(new SetCellValueAndRemoveNotesCommand(cell, value));
+            } else {
+                executeCommand(new SetCellValueCommand(cell, value));
+            }
 
             validate();
             if (isCompleted()) {
@@ -262,13 +269,7 @@ public class SudokuGame {
 
     @Nullable
     public Cell getLastChangedCell() {
-
-        AbstractSingleCellCommand c = mCommandStack.findLatestSingleCellCommand();
-
-        if (c != null) {
-            return c.getCell();
-        }
-        return null;
+        return mCommandStack.getLastChangedCell();
     }
 
     /**

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractCommand.java
@@ -67,7 +67,9 @@ public abstract class AbstractCommand {
             new CommandDef(SetCellValueCommand.class.getSimpleName(), "c4",
                     SetCellValueCommand::new),
             new CommandDef(CheckpointCommand.class.getSimpleName(), "c5",
-                    CheckpointCommand::new)
+                    CheckpointCommand::new),
+            new CommandDef(SetCellValueAndRemoveNotesCommand.class.getSimpleName(), "c6",
+                    SetCellValueAndRemoveNotesCommand::new)
     };
 
     public static AbstractCommand deserialize(StringTokenizer data) {

--- a/app/src/main/java/org/moire/opensudoku/game/command/AbstractMultiNoteCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/AbstractMultiNoteCommand.java
@@ -1,0 +1,70 @@
+package org.moire.opensudoku.game.command;
+
+import org.moire.opensudoku.game.Cell;
+import org.moire.opensudoku.game.CellCollection;
+import org.moire.opensudoku.game.CellNote;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public abstract class AbstractMultiNoteCommand extends AbstractCellCommand {
+
+    protected List<NoteEntry> mOldNotes = new ArrayList<>();
+
+    @Override
+    public void serialize(StringBuilder data) {
+        super.serialize(data);
+
+        data.append(mOldNotes.size()).append("|");
+
+        for (NoteEntry ne : mOldNotes) {
+            data.append(ne.rowIndex).append("|");
+            data.append(ne.colIndex).append("|");
+            ne.note.serialize(data);
+        }
+    }
+
+    @Override
+    protected void _deserialize(StringTokenizer data) {
+        super._deserialize(data);
+
+        int notesSize = Integer.parseInt(data.nextToken());
+        for (int i = 0; i < notesSize; i++) {
+            int row = Integer.parseInt(data.nextToken());
+            int col = Integer.parseInt(data.nextToken());
+
+            mOldNotes.add(new NoteEntry(row, col, CellNote.deserialize(data.nextToken())));
+        }
+    }
+
+    @Override
+    void undo() {
+        CellCollection cells = getCells();
+
+        for (NoteEntry ne : mOldNotes) {
+            cells.getCell(ne.rowIndex, ne.colIndex).setNote(ne.note);
+        }
+    }
+
+    protected void saveOldNotes() {
+        CellCollection cells = getCells();
+        for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
+            for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
+                mOldNotes.add(new NoteEntry(r, c, cells.getCell(r, c).getNote()));
+            }
+        }
+    }
+
+    protected static class NoteEntry {
+        public int rowIndex;
+        public int colIndex;
+        public CellNote note;
+
+        public NoteEntry(int rowIndex, int colIndex, CellNote note) {
+            this.rowIndex = rowIndex;
+            this.colIndex = colIndex;
+            this.note = note;
+        }
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/game/command/ClearAllNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/ClearAllNotesCommand.java
@@ -28,39 +28,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-public class ClearAllNotesCommand extends AbstractCellCommand {
-
-    private List<NoteEntry> mOldNotes = new ArrayList<>();
-
+public class ClearAllNotesCommand extends AbstractMultiNoteCommand {
 
     public ClearAllNotesCommand() {
-    }
-
-
-    @Override
-    public void serialize(StringBuilder data) {
-        super.serialize(data);
-
-        data.append(mOldNotes.size()).append("|");
-
-        for (NoteEntry ne : mOldNotes) {
-            data.append(ne.rowIndex).append("|");
-            data.append(ne.colIndex).append("|");
-            ne.note.serialize(data);
-        }
-    }
-
-    @Override
-    protected void _deserialize(StringTokenizer data) {
-        super._deserialize(data);
-
-        int notesSize = Integer.parseInt(data.nextToken());
-        for (int i = 0; i < notesSize; i++) {
-            int row = Integer.parseInt(data.nextToken());
-            int col = Integer.parseInt(data.nextToken());
-
-            mOldNotes.add(new NoteEntry(row, col, CellNote.deserialize(data.nextToken())));
-        }
     }
 
     @Override
@@ -77,27 +47,6 @@ public class ClearAllNotesCommand extends AbstractCellCommand {
                     cell.setNote(new CellNote());
                 }
             }
-        }
-    }
-
-    @Override
-    void undo() {
-        CellCollection cells = getCells();
-
-        for (NoteEntry ne : mOldNotes) {
-            cells.getCell(ne.rowIndex, ne.colIndex).setNote(ne.note);
-        }
-    }
-
-    private static class NoteEntry {
-        public int rowIndex;
-        public int colIndex;
-        public CellNote note;
-
-        public NoteEntry(int rowIndex, int colIndex, CellNote note) {
-            this.rowIndex = rowIndex;
-            this.colIndex = colIndex;
-            this.note = note;
         }
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/CommandStack.java
@@ -131,12 +131,15 @@ public class CommandStack {
         return mCommandStack.size() != 0;
     }
 
-    public AbstractSingleCellCommand findLatestSingleCellCommand() {
+    public Cell getLastChangedCell() {
         ListIterator<AbstractCommand> iter = mCommandStack.listIterator(mCommandStack.size());
         while (iter.hasPrevious()) {
             AbstractCommand o = iter.previous();
-            if (o instanceof AbstractSingleCellCommand)
-                return (AbstractSingleCellCommand) o;
+            if (o instanceof AbstractSingleCellCommand) {
+                return ((AbstractSingleCellCommand)o).getCell();
+            } else if (o instanceof SetCellValueAndRemoveNotesCommand) {
+                return ((SetCellValueAndRemoveNotesCommand)o).getCell();
+            }
         }
 
         return null;

--- a/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/FillInNotesCommand.java
@@ -9,37 +9,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-public class FillInNotesCommand extends AbstractCellCommand {
-
-    private List<NoteEntry> mOldNotes = new ArrayList<>();
+public class FillInNotesCommand extends AbstractMultiNoteCommand {
 
     public FillInNotesCommand() {
-    }
-
-    @Override
-    public void serialize(StringBuilder data) {
-        super.serialize(data);
-
-        data.append(mOldNotes.size()).append("|");
-
-        for (NoteEntry ne : mOldNotes) {
-            data.append(ne.rowIndex).append("|");
-            data.append(ne.colIndex).append("|");
-            ne.note.serialize(data);
-        }
-    }
-
-    @Override
-    protected void _deserialize(StringTokenizer data) {
-        super._deserialize(data);
-
-        int notesSize = Integer.parseInt(data.nextToken());
-        for (int i = 0; i < notesSize; i++) {
-            int row = Integer.parseInt(data.nextToken());
-            int col = Integer.parseInt(data.nextToken());
-
-            mOldNotes.add(new NoteEntry(row, col, CellNote.deserialize(data.nextToken())));
-        }
     }
 
     @Override
@@ -47,34 +19,8 @@ public class FillInNotesCommand extends AbstractCellCommand {
         CellCollection cells = getCells();
 
         mOldNotes.clear();
-        for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
-            for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
-                mOldNotes.add(new NoteEntry(r, c, cells.getCell(r, c).getNote()));
-            }
-        }
+        saveOldNotes();
 
         cells.fillInNotes();
-    }
-
-    @Override
-    void undo() {
-        CellCollection cells = getCells();
-
-        for (NoteEntry ne : mOldNotes) {
-            cells.getCell(ne.rowIndex, ne.colIndex).setNote(ne.note);
-        }
-    }
-
-    private static class NoteEntry {
-        public int rowIndex;
-        public int colIndex;
-        public CellNote note;
-
-        public NoteEntry(int rowIndex, int colIndex, CellNote note) {
-            this.rowIndex = rowIndex;
-            this.colIndex = colIndex;
-            this.note = note;
-        }
-
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
@@ -11,7 +11,7 @@ public class SetCellValueAndRemoveNotesCommand extends AbstractMultiNoteCommand 
     private int mValue;
     private int mOldValue;
 
-    private Cell getCell() {
+    public Cell getCell() {
         return getCells().getCell(mCellRow, mCellColumn);
     }
 

--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
@@ -1,0 +1,64 @@
+package org.moire.opensudoku.game.command;
+
+import org.moire.opensudoku.game.Cell;
+
+import java.util.StringTokenizer;
+
+public class SetCellValueAndRemoveNotesCommand extends AbstractMultiNoteCommand {
+
+    private int mCellRow;
+    private int mCellColumn;
+    private int mValue;
+    private int mOldValue;
+
+    private Cell getCell() {
+        return getCells().getCell(mCellRow, mCellColumn);
+    }
+
+    public SetCellValueAndRemoveNotesCommand(Cell cell, int value) {
+        mCellRow = cell.getRowIndex();
+        mCellColumn = cell.getColumnIndex();
+        mValue = value;
+    }
+
+    SetCellValueAndRemoveNotesCommand() {
+    }
+
+    @Override
+    public void serialize(StringBuilder data) {
+        super.serialize(data);
+
+        data.append(mCellRow).append("|");
+        data.append(mCellColumn).append("|");
+        data.append(mValue).append("|");
+        data.append(mOldValue).append("|");
+    }
+
+    @Override
+    protected void _deserialize(StringTokenizer data) {
+        super._deserialize(data);
+
+        mValue = Integer.parseInt(data.nextToken());
+        mOldValue = Integer.parseInt(data.nextToken());
+        mCellRow = Integer.parseInt(data.nextToken());
+        mCellColumn = Integer.parseInt(data.nextToken());
+    }
+
+    @Override
+    void execute() {
+        mOldNotes.clear();
+        saveOldNotes();
+
+        Cell cell = getCell();
+        getCells().removeNotesForChangedCell(cell, mValue);
+        mOldValue = cell.getValue();
+        cell.setValue(mValue);
+    }
+
+    @Override
+    void undo() {
+        super.undo();
+        Cell cell = getCell();
+        cell.setValue(mOldValue);
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueCommand.java
@@ -35,7 +35,6 @@ public class SetCellValueCommand extends AbstractSingleCellCommand {
     }
 
     SetCellValueCommand() {
-
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -227,6 +227,8 @@ public class SudokuPlayActivity extends ThemedActivity {
             mSudokuBoard.setHighlightSimilarCell(SudokuBoardView.HighlightMode.NONE);
         }
 
+        mSudokuGame.setRemoveNotesOnEntry(gameSettings.getBoolean("remove_notes_on_input", false));
+
         mShowTime = gameSettings.getBoolean("show_time", true);
         if (mSudokuGame.getState() == SudokuGame.GAME_STATE_PLAYING) {
             mSudokuGame.resume();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -363,4 +363,7 @@
     <!-- Strings added/changed in 3.1.0 -->
     <string name="undo_to_before_mistake">Undo to before mistake</string>
     <string name="undo_to_before_mistake_confirm">Are you sure you want to undo all actions since the last solvable state?</string>
+
+    <string name="remove_notes_summary">Automatically remove notes from the same column, row, and box when entering a number</string>
+    <string name="remove_notes_title">Remove notes on entry</string>
 </resources>

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -37,6 +37,11 @@
             android:key="fill_in_notes_enabled"
             android:summary="@string/fill_in_notes_summary"
             android:title="@string/fill_in_notes" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="remove_notes_on_input"
+            android:summary="@string/remove_notes_summary"
+            android:title="@string/remove_notes_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/input_methods">
         <CheckBoxPreference


### PR DESCRIPTION
This PR adds a feature to automatically remove all the notes in the same column, row, and box when entering a number in a cell. This can be disabled in settings and is off by default. This addresses feature request #31 .

If you use this feature, both the number entry and all the note removals are grouped together into the same command so that you can undo the entire operation as a logical unit.

This PR also adds a new abstract base class -- `AbstractMultiNoteCommand` -- to centralize some of the common behavior between `FillInNotesCommand`, `ClearAllNotesCommand`, and the new `SetCellValueAndRemoveNotesCommand`.

Scenarios Tested
====
- Verified entering a number with and without the remove notes feature active.
- Verified clearing an existing number doesn't cause a crash (when trying to remove notes for '0').