### PR TITLE
Add option to skip titlescreen, fix hint crash, fix custom themes bug

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
@@ -129,6 +129,10 @@ public class FolderListActivity extends ThemedActivity {
             }
         });
         registerForContextMenu(mListView);
+
+        // show changelog on first run
+        Changelog changelog = new Changelog(this);
+        changelog.showOnFirstRun();
     }
 
     @Override

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuListActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuListActivity.java
@@ -503,6 +503,10 @@ public class SudokuListActivity extends ThemedActivity {
                     board.setReadOnly(true);
                     board.setFocusable(false);
                     ((SudokuBoardView) view).setCells(cells);
+                    ThemeUtils.applyThemeToSudokuBoardViewFromContext(
+                            ThemeUtils.getCurrentThemeFromPreferences(mContext),
+                            board,
+                            mContext);
                     break;
                 case R.id.state:
                     label = ((TextView) view);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -201,17 +201,7 @@ public class SudokuPlayActivity extends ThemedActivity {
 
         String theme = gameSettings.getString("theme", "opensudoku");
         if (theme.equals("custom") || theme.equals("custom_light")) {
-            mSudokuBoard.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
-            mSudokuBoard.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
-            mSudokuBoard.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
-            mSudokuBoard.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
-            mSudokuBoard.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
-            mSudokuBoard.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
-            mSudokuBoard.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
-            mSudokuBoard.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
-            mSudokuBoard.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
-            mSudokuBoard.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
-            mSudokuBoard.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+            ThemeUtils.applyCustomThemeToSudokuBoardViewFromContext(mSudokuBoard, getApplicationContext());
         }
 
         mSudokuBoard.setHighlightWrongVals(gameSettings.getBoolean("highlight_wrong_values", true));

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuPlayActivity.java
@@ -553,7 +553,7 @@ public class SudokuPlayActivity extends ThemedActivity {
                         .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int whichButton) {
                                 Cell cell = mSudokuBoard.getSelectedCell();
-                                if (cell.isEditable()) {
+                                if (cell != null && cell.isEditable()) {
                                     if (mSudokuGame.isSolvable()) {
                                         mSudokuGame.solveCell(cell);
                                     }

--- a/app/src/main/java/org/moire/opensudoku/gui/TitleScreenActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/TitleScreenActivity.java
@@ -47,9 +47,17 @@ public class TitleScreenActivity extends ThemedActivity {
             startActivity(new Intent(this, GameSettingsActivity.class));
         });
 
-        // show changelog on first run
-        Changelog changelog = new Changelog(this);
-        changelog.showOnFirstRun();
+        // check the preference to skip the title screen and launch the folder list activity
+        // directly
+        SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        boolean showSudokuFolderListOnStartup = gameSettings.getBoolean("show_sudoku_lists_on_startup", false);
+        if (showSudokuFolderListOnStartup) {
+            startActivity(new Intent(this, FolderListActivity.class));
+        } else {
+            // show changelog on first run
+            Changelog changelog = new Changelog(this);
+            changelog.showOnFirstRun();
+        }
     }
 
     private void setupResumeButton() {

--- a/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
+++ b/app/src/main/java/org/moire/opensudoku/utils/ThemeUtils.java
@@ -160,21 +160,24 @@ public class ThemeUtils {
         }
     }
 
+    public static void applyCustomThemeToSudokuBoardViewFromContext(SudokuBoardView board, Context context) {
+        SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(context);
+        board.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
+        board.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
+        board.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
+        board.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
+        board.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
+        board.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
+        board.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
+        board.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
+        board.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
+        board.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
+        board.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+    }
+
     public static void applyThemeToSudokuBoardViewFromContext(String theme, SudokuBoardView board, Context context) {
         if (theme.equals("custom") || theme.equals("custom_light")) {
-
-            SharedPreferences gameSettings = PreferenceManager.getDefaultSharedPreferences(context);
-            board.setLineColor(gameSettings.getInt("custom_theme_lineColor", R.color.default_lineColor));
-            board.setSectorLineColor(gameSettings.getInt("custom_theme_sectorLineColor", R.color.default_sectorLineColor));
-            board.setTextColor(gameSettings.getInt("custom_theme_textColor", R.color.default_textColor));
-            board.setTextColorReadOnly(gameSettings.getInt("custom_theme_textColorReadOnly", R.color.default_textColorReadOnly));
-            board.setTextColorNote(gameSettings.getInt("custom_theme_textColorNote", R.color.default_textColorNote));
-            board.setBackgroundColor(gameSettings.getInt("custom_theme_backgroundColor", R.color.default_backgroundColor));
-            board.setBackgroundColorSecondary(gameSettings.getInt("custom_theme_backgroundColorSecondary", R.color.default_backgroundColorSecondary));
-            board.setBackgroundColorReadOnly(gameSettings.getInt("custom_theme_backgroundColorReadOnly", R.color.default_backgroundColorReadOnly));
-            board.setBackgroundColorTouched(gameSettings.getInt("custom_theme_backgroundColorTouched", R.color.default_backgroundColorTouched));
-            board.setBackgroundColorSelected(gameSettings.getInt("custom_theme_backgroundColorSelected", R.color.default_backgroundColorSelected));
-            board.setBackgroundColorHighlighted(gameSettings.getInt("custom_theme_backgroundColorHighlighted", R.color.default_backgroundColorHighlighted));
+            applyCustomThemeToSudokuBoardViewFromContext(board, context);
         } else {
             ContextThemeWrapper themeWrapper = new ContextThemeWrapper(context, getThemeResourceIdFromString(theme));
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -369,4 +369,8 @@
     <string name="remove_notes_title">Remove notes on number entry</string>
 
     <string name="create_from_single_color">Create from single color…</string>
+
+    <string name="show_sudoku_lists_on_startup_summary">Show the sudoku lists on startup and skip the title screen.</string>
+    <string name="show_sudoku_lists_on_startup_title">Show sudoku lists on startup</string>
+    <string name="app_startup_category">App Startup</string>
 </resources>

--- a/app/src/main/res/xml/game_settings.xml
+++ b/app/src/main/res/xml/game_settings.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:os="http://schemas.android.com/apk/res-auto">
+    <PreferenceCategory android:title="@string/app_startup_category">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="show_sudoku_lists_on_startup"
+            android:summary="@string/show_sudoku_lists_on_startup_summary"
+            android:title="@string/show_sudoku_lists_on_startup_title"
+            />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/game_helpers">
         <CheckBoxPreference
             android:defaultValue="true"


### PR DESCRIPTION
This PR addresses issues #65, #64, and #62 by fixing a few bugs and adding a feature to skip the new title screen and launch directly on the Sudoku list screen.

Skip Titlescreen
====
Per user feedback, this PR adds a new option "Show sudoku lists on startup" that will launch the app directly to the sudoku lists screen on startup. The title screen will still be accessible via back navigation, but the app will start on the lists activity.

Hint Crash
====
If you used the "hint" command from the options menu when no cell was selected, the activity would crash. This PR adds a null check to make sure the "couldn't show hint" dialog is shown instead.

Sudoku Preview Colors in Folder View
====
If you are using a custom theme instead of a built-in theme, the sudoku previews that are shown in the folder views were always black-and-white. This PR changes it to reflect the current custom theme colors.

Scenarios Tested
====
- Launched into the app with and without the "show sudoku lists on startup" option.
- Verified changelog is displayed on either the title screen or the sudoku lists screen, depending on what option is selected.
- Verified selecting the "hint" command when a cell is not selected shows the hint error dialog (instead of a crash).
- Verified the Sudoku previews in the sudoku folder activity are colored using the colors in the custom theme if the custom theme is selected.
- Verified the Sudoku previews in the sudoku folder activity are colored correctly when using a normal theme. 