### PR TITLE
Fix crash when using the new feature to automatically remove cell notes

### DIFF
--- a/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
+++ b/app/src/main/java/org/moire/opensudoku/game/command/SetCellValueAndRemoveNotesCommand.java
@@ -38,10 +38,10 @@ public class SetCellValueAndRemoveNotesCommand extends AbstractMultiNoteCommand 
     protected void _deserialize(StringTokenizer data) {
         super._deserialize(data);
 
-        mValue = Integer.parseInt(data.nextToken());
-        mOldValue = Integer.parseInt(data.nextToken());
         mCellRow = Integer.parseInt(data.nextToken());
         mCellColumn = Integer.parseInt(data.nextToken());
+        mValue = Integer.parseInt(data.nextToken());
+        mOldValue = Integer.parseInt(data.nextToken());
     }
 
     @Override


### PR DESCRIPTION
This fixes a bug where if you use the new "automatically remove notes on entry" feature and you entered the number "9", you would crash if you ever left the puzzle and restarted it. It is possible to get into a state where loading a game-in-progress will always cause a crash. This is bad!

This was caused by a bug in the deserialization code for the new command.
 
Fortunately, with this fix, existing games that are in this state will be fixed when upgrading to the latest version and play can continue.