### PR TITLE
Add ability to generate games

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId "org.moire.opensudoku"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -93,6 +93,9 @@
             android:name=".gui.SudokuGenerateActivity"
             android:label="@string/app_name"></activity>
         <activity
+            android:name=".gui.SudokuDownloadActivity"
+            android:label="@string/app_name"></activity>
+        <activity
             android:name=".gui.SudokuExportActivity"
             android:label="@string/app_name"></activity>
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,10 @@
                     android:scheme="file" />
                 <data
                     android:host="*"
+                    android:pathPattern=".*\\.opensudoku.xml"
+                    android:scheme="file" />
+                <data
+                    android:host="*"
                     android:pathPattern=".*\\.opensudoku"
                     android:scheme="http" />
             </intent-filter>
@@ -85,6 +89,9 @@
                 <data android:mimeType="application/x-opensudoku" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".gui.SudokuGenerateActivity"
+            android:label="@string/app_name"></activity>
         <activity
             android:name=".gui.SudokuExportActivity"
             android:label="@string/app_name"></activity>

--- a/app/src/main/java/org/moire/opensudoku/game/Cell.java
+++ b/app/src/main/java/org/moire/opensudoku/game/Cell.java
@@ -20,7 +20,11 @@
 
 package org.moire.opensudoku.game;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.StringTokenizer;
+
+import static org.moire.opensudoku.game.CellCollection.SUDOKU_SIZE;
 
 /**
  * Sudoku cell. Every cell has value, some notes attached to it and some basic
@@ -71,6 +75,10 @@ public class Cell {
         mValid = valid;
     }
 
+    public Cell copy() {
+        return new Cell(mValue, mNote, mEditable, mValid);
+    }
+
     /**
      * Gets cell's row index within {@link CellCollection}.
      *
@@ -113,6 +121,36 @@ public class Cell {
         sector.addCell(this);
         row.addCell(this);
         column.addCell(this);
+    }
+
+    /**
+     * Fills in all valid notes for this cell based on the values in each row, column, and sector.
+     * This is a destructive operation in that the existing notes are overwritten.
+     */
+    public void fillInNotes() {
+        setNote(new CellNote());
+        for (int n : getPossibleSolutions()) {
+            setNote(getNote().addNumber(n));
+        }
+    }
+
+    /**
+     * Returns a list of possible values for this cell.
+     *
+     * @return all possible values for this cell
+     */
+    public List<Integer> getPossibleSolutions() {
+        CellGroup row = getRow();
+        CellGroup column = getColumn();
+        CellGroup sector = getSector();
+
+        List<Integer> values = new ArrayList<>();
+        for (int i = 1; i <= SUDOKU_SIZE; i++) {
+            if (row.DoesntContain(i) && column.DoesntContain(i) && sector.DoesntContain(i)) {
+                values.add(i);
+            }
+        }
+        return values;
     }
 
     /**

--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -265,22 +265,13 @@ public class CellCollection {
         for (int r = 0; r < SUDOKU_SIZE; r++) {
             for (int c = 0; c < SUDOKU_SIZE; c++) {
                 Cell cell = getCell(r, c);
-                cell.setNote(new CellNote());
-
-                CellGroup row = cell.getRow();
-                CellGroup column = cell.getColumn();
-                CellGroup sector = cell.getSector();
-                for (int i = 1; i <= SUDOKU_SIZE; i++) {
-                    if (row.DoesntContain(i) && column.DoesntContain(i) && sector.DoesntContain(i)) {
-                        cell.setNote(cell.getNote().addNumber(i));
-                    }
-                }
+                cell.fillInNotes();
             }
         }
     }
 
     public void removeNotesForChangedCell(Cell cell, int number) {
-        if (number < 1 || number> 9) {
+        if (number < 1 || number > 9) {
             return;
         }
 
@@ -375,7 +366,7 @@ public class CellCollection {
      * created by {@link #serialize(StringBuilder)} or {@link #serialize()} method).
      * earlier.
      *
-     * @param note
+     * @param data
      */
     public static CellCollection deserialize(String data) {
         // TODO: use DATA_PATTERN_VERSION_1 to validate and extract puzzle data
@@ -503,7 +494,7 @@ public class CellCollection {
     /**
      * Returns true, if given <code>data</code> conform to format of any version.
      *
-     * @param data
+     * @param data string
      * @return
      */
     public static boolean isValid(String data) {
@@ -580,5 +571,21 @@ public class CellCollection {
          * Called when anything in the collection changes (cell's value, note, etc.)
          */
         void onChange();
+    }
+
+
+    public CellCollection copy() {
+        Cell[][] cells = new Cell[SUDOKU_SIZE][SUDOKU_SIZE];
+        for (int r = 0; r < SUDOKU_SIZE; r++) {
+            for (int c = 0; c < SUDOKU_SIZE; c++) {
+                cells[r][c] = mCells[r][c].copy();
+            }
+        }
+
+        CellCollection newCells = new CellCollection(cells);
+        if (!toDataString().equals(newCells.toDataString()))
+            throw new RuntimeException("Copy is not equal??");
+
+        return newCells;
     }
 }

--- a/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
+++ b/app/src/main/java/org/moire/opensudoku/game/CellCollection.java
@@ -431,6 +431,24 @@ public class CellCollection {
         return new CellCollection(cells);
     }
 
+    /**
+     * Creates a string from the collection. The string is in
+     * the format "00002343243202...", where each number represents
+     * cell value, no other information can be set using this method.
+     *
+     * @return data string
+     */
+    public String toDataString() {
+        StringBuilder sb = new StringBuilder();
+        for (int r = 0; r < CellCollection.SUDOKU_SIZE; r++) {
+            for (int c = 0; c < CellCollection.SUDOKU_SIZE; c++) {
+                Cell cell = mCells[r][c];
+                sb.append(cell.getValue());
+            }
+        }
+        return sb.toString();
+    }
+
     public String serialize() {
         StringBuilder sb = new StringBuilder();
         serialize(sb);

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -22,12 +22,8 @@ package org.moire.opensudoku.game;
 
 import android.os.Bundle;
 import android.os.SystemClock;
-import android.util.Log;
-
 import androidx.annotation.Nullable;
-
 import java.util.ArrayList;
-import java.util.Random;
 
 import org.moire.opensudoku.game.command.AbstractCommand;
 import org.moire.opensudoku.game.command.ClearAllNotesCommand;
@@ -36,8 +32,6 @@ import org.moire.opensudoku.game.command.EditCellNoteCommand;
 import org.moire.opensudoku.game.command.FillInNotesCommand;
 import org.moire.opensudoku.game.command.SetCellValueAndRemoveNotesCommand;
 import org.moire.opensudoku.game.command.SetCellValueCommand;
-
-import static org.moire.opensudoku.utils.Const.TAG;
 
 public class SudokuGame {
 
@@ -67,31 +61,6 @@ public class SudokuGame {
         // set creation time
         game.setCreated(System.currentTimeMillis());
         return game;
-    }
-
-    public static SudokuGame generateNewGame(int numberOfEmptyCells) {
-        SudokuGame game;
-        int attempts = 0;
-        do {
-            Log.d(TAG, "generateNewGame: Generating attempt: "+(++attempts));
-            game = createEmptyGame();
-            game.solve();
-            game.clearRandomCells(numberOfEmptyCells);
-        } while (!game.isSolvable()); // pretty sure this will always be true
-        return game;
-    }
-
-    public void clearRandomCells(int numberOfEmptyCells) {
-        Random random = new Random();
-        for (int i = 0; i < numberOfEmptyCells; i++) {
-            int randomRow = random.nextInt(9);
-            int randomColumn = random.nextInt(9);
-
-            Cell cell = mCells.getCell(randomRow, randomColumn);
-            int value = cell.getValue();
-            if (value != 0) cell.setValue(0);
-            else i--;
-        }
     }
 
     public String toDataString() {
@@ -344,9 +313,16 @@ public class SudokuGame {
      * Solves puzzle from original state
      */
     public void solve() {
+        solve(true);
+    }
+
+    /**
+     * Solves puzzle from selected state
+     */
+    public void solve(boolean originalState) {
         mUsedSolver = true;
         mSolver = new SudokuSolver();
-        mSolver.setPuzzle(mCells);
+        mSolver.setPuzzle(mCells, originalState);
         ArrayList<int[]> finalValues = mSolver.solve();
         for (int[] rowColVal : finalValues) {
             int row = rowColVal[0];

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGame.java
@@ -22,10 +22,12 @@ package org.moire.opensudoku.game;
 
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.util.Log;
 
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Random;
 
 import org.moire.opensudoku.game.command.AbstractCommand;
 import org.moire.opensudoku.game.command.ClearAllNotesCommand;
@@ -34,6 +36,8 @@ import org.moire.opensudoku.game.command.EditCellNoteCommand;
 import org.moire.opensudoku.game.command.FillInNotesCommand;
 import org.moire.opensudoku.game.command.SetCellValueAndRemoveNotesCommand;
 import org.moire.opensudoku.game.command.SetCellValueCommand;
+
+import static org.moire.opensudoku.utils.Const.TAG;
 
 public class SudokuGame {
 
@@ -63,6 +67,35 @@ public class SudokuGame {
         // set creation time
         game.setCreated(System.currentTimeMillis());
         return game;
+    }
+
+    public static SudokuGame generateNewGame(int numberOfEmptyCells) {
+        SudokuGame game;
+        int attempts = 0;
+        do {
+            Log.d(TAG, "generateNewGame: Generating attempt: "+(++attempts));
+            game = createEmptyGame();
+            game.solve();
+            game.clearRandomCells(numberOfEmptyCells);
+        } while (!game.isSolvable()); // pretty sure this will always be true
+        return game;
+    }
+
+    public void clearRandomCells(int numberOfEmptyCells) {
+        Random random = new Random();
+        for (int i = 0; i < numberOfEmptyCells; i++) {
+            int randomRow = random.nextInt(9);
+            int randomColumn = random.nextInt(9);
+
+            Cell cell = mCells.getCell(randomRow, randomColumn);
+            int value = cell.getValue();
+            if (value != 0) cell.setValue(0);
+            else i--;
+        }
+    }
+
+    public String toDataString() {
+        return mCells.toDataString();
     }
 
     public SudokuGame() {
@@ -300,7 +333,7 @@ public class SudokuGame {
     /**
      * Checks if a solution to the puzzle exists
      */
-    public boolean isSolvable () {
+    public boolean isSolvable() {
         mSolver = new SudokuSolver();
         mSolver.setPuzzle(mCells);
         ArrayList<int[]> finalValues = mSolver.solve();

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuGenerator.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuGenerator.java
@@ -1,0 +1,231 @@
+package org.moire.opensudoku.game;
+
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static org.moire.opensudoku.game.CellCollection.SUDOKU_SIZE;
+
+public class SudokuGenerator {
+    private static String TAG = SudokuGenerator.class.getName();
+
+    final private Random mRandom;
+    private int mAttempts;
+    private int mTotalAttempts;
+    private int mGames;
+
+    public SudokuGenerator()
+    {
+        mGames = 0;
+        mAttempts = 0;
+        mTotalAttempts = 0;
+        mRandom = new Random();
+    }
+
+    /**
+     * Generates a random game.
+     * This puts some effort into creating a game with a unique solution
+     * but in order to save time, only 1-level is checked as we unset cells.
+     */
+    public SudokuGame generate(int numberOfEmptyCells)
+    {
+        SudokuGame game = generateSolvedGame();
+        CellCollection cells = game.getCells();
+        print("Solution:\n", cells);
+
+        mAttempts = 1;
+        mGames++;
+
+        // loop through and randomly unset numberOfEmptyCells
+        int i = 0;
+        while (i < numberOfEmptyCells) {
+            int randomRow = mRandom.nextInt(SUDOKU_SIZE);
+            int randomColumn = mRandom.nextInt(SUDOKU_SIZE);
+
+            Cell cell = cells.getCell(randomRow, randomColumn);
+            int value = cell.getValue();
+            if (value != 0) {
+                // unset the cell and check that it only has 1 unique solution
+                // if so, move on, otherwise, attempt to unset a different cell
+                cell.setValue(0);
+                if (isUniqueSolution(cell, cells)) i++;
+                else {
+                    mAttempts++;
+                    Log.d(TAG, "generate: Game: "+mGames+" Attempt: "+mAttempts);
+                    cell.setValue(value); // restore the solved value
+                }
+            }
+        }
+
+//        mAttempts = 0;
+//        CellCollection cells;
+//        do {
+//            mAttempts++;
+//            Log.d(TAG, "generate: Attempt: "+mAttempts);
+//            cells = randomlyUnsetCells(game.getCells(), numberOfEmptyCells);
+//        } while(!isUniqueSolution(cells));
+
+        // success
+        mTotalAttempts += mAttempts;
+        game.setCells(cells);
+        print("Unsolved (attempts="+mAttempts+"):\n", game.getCells());
+        return game;
+    }
+
+    /**
+     * Quickly generates a completely solved game
+     */
+    private SudokuGame generateSolvedGame()
+    {
+        SudokuGame game = SudokuGame.createEmptyGame();
+        CellCollection cells = game.getCells();
+
+        // Randomize the diagonal sectors and solve the whole board (creates random solution)
+        randomize(cells.getCell(0, 0).getSector(), mRandom);
+        randomize(cells.getCell(3, 3).getSector(), mRandom);
+        randomize(cells.getCell(6, 6).getSector(), mRandom);
+        game.solve(false);
+
+        return game;
+    }
+
+    /**
+     * Randomizes the values in the group.
+     * Warning: this rewrites the values current present.
+     */
+    private void randomize(CellGroup group, Random random) {
+        List<Integer> values = Arrays.asList(1,2,3,4,5,6,7,8,9);
+        Collections.shuffle(values, random); // brand new values
+
+        Cell[] cells = group.getCells();
+        for (int i=0; i<SUDOKU_SIZE; i++) {
+            cells[i].setValue(values.get(i));
+        }
+    }
+
+//    private CellCollection randomlyUnsetCells(CellCollection cells, int numberOfEmptyCells)
+//    {
+//        CellCollection newCells = cells.copy();
+//
+//        // loop through and randomly unset numberOfEmptyCells
+//        int i = 0;
+//        while (i < numberOfEmptyCells) {
+//            int randomRow = mRandom.nextInt(SUDOKU_SIZE);
+//            int randomColumn = mRandom.nextInt(SUDOKU_SIZE);
+//
+//            Cell cell = newCells.getCell(randomRow, randomColumn);
+//            int value = cell.getValue();
+//            if (value != 0)  {
+//                cell.setValue(0);
+//                if (isUniqueSolution(newCells)) i++;
+//                else cell.setValue(0);
+//            }
+//        }
+//
+//        return newCells;
+//    }
+
+
+    /**
+     * Checks if every cell in the collection has a unique solution
+     */
+    private boolean isUniqueSolution(CellCollection cells)
+    {
+        print("Testing:\n", cells);
+
+        // loop through all cells
+        for (int r = 0; r < SUDOKU_SIZE; r++) {
+            for (int c = 0; c < SUDOKU_SIZE; c++) {
+                Cell cell = cells.getCell(r, c);
+                // for every empty cell
+                if (cell.getValue() == 0) {
+                    if (!isUniqueSolution(cell, cells))
+                        return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Checks if the given cell has a unique solution in the cell collection
+     **/
+    private boolean isUniqueSolution(Cell cell, CellCollection cells)
+    {
+        String subject = cell.getRow()+","+cell.getColumn();
+
+        // loop through possible solutions in that cell
+        List<Integer> possibleSolutions = cell.getPossibleSolutions();
+        Log.d(TAG, "isUniqueSolution: "+subject+" has possible solutions "+possibleSolutions);
+        boolean solutionFound = false;
+        for (int value : possibleSolutions) {
+            Log.d(TAG, "isUniqueSolution: Testing "+subject+" = "+value);
+            cell.setValue(value); // set
+            // if more than one solution is found, fail
+            if (isSolvable(cells)) {
+                Log.d(TAG, "isUniqueSolution: Solution!");
+                if (solutionFound)
+                    return false;
+                solutionFound = true;
+            }
+            cell.setValue(0);  // restore
+        }
+
+        if (!solutionFound)
+            throw new RuntimeException("No solution found for cell");
+
+        return true;
+    }
+
+    /**
+     * Checks if the cells, in their current state, are solvable
+     */
+    public boolean isSolvable(CellCollection cells)
+    {
+        if (cells.isCompleted()) return true;
+
+        SudokuSolver solver = new SudokuSolver();
+        solver.setPuzzle(cells, false);
+        return !solver.solve().isEmpty();
+    }
+
+
+    /**
+     * Get number of attempts it took to generate a game.
+     * This number resets every time generate() is called.
+     *
+     * @return number of attempts
+     */
+    public int getAttempts()
+    {
+        return mAttempts;
+    }
+
+    /**
+     * Get number of total attempts so far on the generator.
+     * This number totals all attempts since the generator was created.
+     *
+     * @return number of total attempts
+     */
+    public int getTotalAttempts()
+    {
+        return mTotalAttempts;
+    }
+
+    public void print(String prefix, CellCollection cells)
+    {
+        StringBuilder sb = new StringBuilder();
+        for (int r = 0; r < SUDOKU_SIZE; r++) {
+            for (int c = 0; c < SUDOKU_SIZE; c++) {
+                Cell cell = cells.getCell(r, c);
+                sb.append(cell.getValue()).append("  ");
+            }
+            sb.append('\n');
+        }
+        Log.d(TAG, prefix+sb.toString());
+    }
+
+}

--- a/app/src/main/java/org/moire/opensudoku/game/SudokuSolver.java
+++ b/app/src/main/java/org/moire/opensudoku/game/SudokuSolver.java
@@ -27,13 +27,20 @@ public class SudokuSolver {
      * Modifies linked list based on the original state of the board
      */
     public void setPuzzle(CellCollection mCells) {
+        setPuzzle(mCells, true);
+    }
+
+    /**
+     * Modifies linked list based on the selected state of the board
+     */
+    public void setPuzzle(CellCollection mCells, boolean originalState) {
         Cell[][] board = mCells.getCells();
 
         for (int row = 0; row < 9; row++) {
             for (int col = 0; col < 9; col++) {
                 Cell cell = board[row][col];
                 int val = cell.getValue();
-                if (!cell.isEditable()) {
+                if (originalState ? !cell.isEditable() : val != 0) {
                     int matrixRow = cellToRow(row, col, val-1, true);
                     int matrixCol = 9*row + col; // calculates column of node based on cell constraint
 

--- a/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
@@ -55,6 +55,8 @@ import org.moire.opensudoku.R;
 import org.moire.opensudoku.db.FolderColumns;
 import org.moire.opensudoku.db.SudokuDatabase;
 import org.moire.opensudoku.game.FolderInfo;
+import org.moire.opensudoku.gen.Generator;
+import org.moire.opensudoku.gui.importing.ExtrasImportTask;
 import org.moire.opensudoku.utils.AndroidUtils;
 import org.moire.opensudoku.utils.ThemeUtils;
 
@@ -73,6 +75,7 @@ public class FolderListActivity extends ThemedActivity {
     public static final int MENU_ITEM_EXPORT_ALL = Menu.FIRST + 5;
     public static final int MENU_ITEM_IMPORT = Menu.FIRST + 6;
     public static final int MENU_ITEM_SETTINGS = Menu.FIRST + 7;
+    public static final int MENU_ITEM_GEN = Menu.FIRST + 8;
 
     private static final int DIALOG_ABOUT = 0;
     private static final int DIALOG_ADD_FOLDER = 1;
@@ -176,6 +179,9 @@ public class FolderListActivity extends ThemedActivity {
                 .setIcon(R.drawable.ic_add);
         menu.add(0, MENU_ITEM_IMPORT, 0, R.string.import_file)
                 .setShortcut('8', 'i')
+                .setIcon(R.drawable.ic_cloud_upload);
+        menu.add(0, MENU_ITEM_GEN, 0, R.string.generate)
+                .setShortcut('2', 'g')
                 .setIcon(R.drawable.ic_cloud_upload);
         menu.add(0, MENU_ITEM_EXPORT_ALL, 1, R.string.export_all_folders)
                 .setShortcut('7', 'e')
@@ -357,6 +363,15 @@ public class FolderListActivity extends ThemedActivity {
                 else {
                     startActivity(intent);
                 }
+                return true;
+            case MENU_ITEM_GEN:
+                intent = new Intent();
+                //intent.putExtra(SudokuGenerateActivity.EXTRA_FOLDER_NAME, "Generated");
+                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_GAMES, 20);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_EMPTY_CELLS, 60);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_APPEND_TO_FOLDER, true);
+                intent.setClass(this, SudokuGenerateActivity.class);
+                startActivity(intent);
                 return true;
             case MENU_ITEM_EXPORT_ALL:
                 intent = new Intent();

--- a/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
@@ -33,7 +33,6 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
@@ -55,10 +54,7 @@ import org.moire.opensudoku.R;
 import org.moire.opensudoku.db.FolderColumns;
 import org.moire.opensudoku.db.SudokuDatabase;
 import org.moire.opensudoku.game.FolderInfo;
-import org.moire.opensudoku.gen.Generator;
-import org.moire.opensudoku.gui.importing.ExtrasImportTask;
 import org.moire.opensudoku.utils.AndroidUtils;
-import org.moire.opensudoku.utils.ThemeUtils;
 
 /**
  * List of puzzle's folder. This activity also serves as root activity of application.
@@ -75,7 +71,8 @@ public class FolderListActivity extends ThemedActivity {
     public static final int MENU_ITEM_EXPORT_ALL = Menu.FIRST + 5;
     public static final int MENU_ITEM_IMPORT = Menu.FIRST + 6;
     public static final int MENU_ITEM_SETTINGS = Menu.FIRST + 7;
-    public static final int MENU_ITEM_GEN = Menu.FIRST + 8;
+    public static final int MENU_ITEM_GENERATE = Menu.FIRST + 8;
+    public static final int MENU_ITEM_DOWNLOAD = Menu.FIRST + 9;
 
     private static final int DIALOG_ABOUT = 0;
     private static final int DIALOG_ADD_FOLDER = 1;
@@ -180,9 +177,12 @@ public class FolderListActivity extends ThemedActivity {
         menu.add(0, MENU_ITEM_IMPORT, 0, R.string.import_file)
                 .setShortcut('8', 'i')
                 .setIcon(R.drawable.ic_cloud_upload);
-        menu.add(0, MENU_ITEM_GEN, 0, R.string.generate)
-                .setShortcut('2', 'g')
+        menu.add(0, MENU_ITEM_DOWNLOAD, 0, R.string.download)
+                .setShortcut('9', 'd')
                 .setIcon(R.drawable.ic_cloud_upload);
+        menu.add(0, MENU_ITEM_GENERATE, 0, R.string.generate)
+                .setShortcut('2', 'g')
+                .setIcon(R.drawable.ic_add);
         menu.add(0, MENU_ITEM_EXPORT_ALL, 1, R.string.export_all_folders)
                 .setShortcut('7', 'e')
                 .setIcon(R.drawable.ic_share);
@@ -364,13 +364,17 @@ public class FolderListActivity extends ThemedActivity {
                     startActivity(intent);
                 }
                 return true;
-            case MENU_ITEM_GEN:
+            case MENU_ITEM_GENERATE:
                 intent = new Intent();
-                //intent.putExtra(SudokuGenerateActivity.EXTRA_FOLDER_NAME, "Generated");
-                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_GAMES, 20);
-                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_EMPTY_CELLS, 60);
-                intent.putExtra(SudokuGenerateActivity.EXTRA_APPEND_TO_FOLDER, true);
                 intent.setClass(this, SudokuGenerateActivity.class);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_GAMES, 20);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_EMPTY_CELLS, 55);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_APPEND_TO_FOLDER, true);
+                startActivity(intent);
+                return true;
+            case MENU_ITEM_DOWNLOAD:
+                intent = new Intent();
+                intent.setClass(this, SudokuDownloadActivity.class);
                 startActivity(intent);
                 return true;
             case MENU_ITEM_EXPORT_ALL:

--- a/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/FolderListActivity.java
@@ -367,7 +367,7 @@ public class FolderListActivity extends ThemedActivity {
             case MENU_ITEM_GENERATE:
                 intent = new Intent();
                 intent.setClass(this, SudokuGenerateActivity.class);
-                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_GAMES, 20);
+                intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_GAMES, 5);
                 intent.putExtra(SudokuGenerateActivity.EXTRA_NUM_EMPTY_CELLS, 55);
                 intent.putExtra(SudokuGenerateActivity.EXTRA_APPEND_TO_FOLDER, true);
                 startActivity(intent);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuDownloadActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuDownloadActivity.java
@@ -1,0 +1,56 @@
+package org.moire.opensudoku.gui;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.text.format.DateFormat;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+
+import org.moire.opensudoku.R;
+import org.moire.opensudoku.gui.importing.GenerateImportTask;
+
+import java.util.Date;
+
+public class SudokuDownloadActivity extends ThemedActivity {
+
+    private static final String TAG = SudokuDownloadActivity.class.getSimpleName();
+
+    public static final String EXTRA_FOLDER_NAME = SudokuImportActivity.EXTRA_FOLDER_NAME;
+    public static final String EXTRA_APPEND_TO_FOLDER = SudokuImportActivity.EXTRA_APPEND_TO_FOLDER;
+
+    private EditText mFolderNameEdit;
+    private EditText mUrlEdit;
+    private CheckBox mAppendToFolderCb;
+
+    private GenerateImportTask mGenTask;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.sudoku_dl);
+
+        mFolderNameEdit = findViewById(R.id.dl_folder_name);
+        mUrlEdit = findViewById(R.id.dl_url);
+        mAppendToFolderCb = findViewById(R.id.dl_append);
+
+        Intent intent = getIntent();
+        String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
+        mFolderNameEdit.setText(folderName == null
+                ? "Dl_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()
+                : folderName);
+
+        mAppendToFolderCb.setChecked(intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false));
+
+        Button mDlButton = findViewById(R.id.dl_button);
+        mDlButton.setOnClickListener(v -> {
+            Intent i = new Intent(this, SudokuImportActivity.class);
+            i.setData(Uri.parse(mUrlEdit.getText().toString()));
+            i.putExtra(EXTRA_FOLDER_NAME, mFolderNameEdit.getText().toString());
+            i.putExtra(EXTRA_APPEND_TO_FOLDER, mAppendToFolderCb.isChecked());
+            startActivity(i);
+        });
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
@@ -43,7 +43,7 @@ public class SudokuGenerateActivity extends ThemedActivity {
         Intent intent = getIntent();
         String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
         mFolderNameEdit.setText(folderName == null
-                ? "Gen_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()+"_{games}x{empty}"
+                ? "Gen_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()+"_{empty}"
                 : folderName);
 
         mNumEmptyCellsPicker.setMinValue(1);
@@ -59,7 +59,6 @@ public class SudokuGenerateActivity extends ThemedActivity {
         Button mGenButton = findViewById(R.id.gen_button);
         mGenButton.setOnClickListener(v -> {
             String folder = mFolderNameEdit.getText().toString()
-                    .replace("{games}", Integer.toString(mNumGamesPicker.getValue()))
                     .replace("{empty}", Integer.toString(mNumEmptyCellsPicker.getValue()));
 
             Intent i = new Intent(this, SudokuImportActivity.class);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
@@ -1,0 +1,69 @@
+package org.moire.opensudoku.gui;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.text.format.DateFormat;
+import android.widget.Button;
+import android.widget.CheckBox;
+import android.widget.EditText;
+import android.widget.NumberPicker;
+
+import org.moire.opensudoku.R;
+import org.moire.opensudoku.gui.importing.GenImportTask;
+
+import java.util.Date;
+
+public class SudokuGenerateActivity extends ThemedActivity {
+
+    private static final String TAG = SudokuGenerateActivity.class.getSimpleName();
+
+    public static final String EXTRA_FOLDER_NAME = SudokuImportActivity.EXTRA_FOLDER_NAME;
+    public static final String EXTRA_APPEND_TO_FOLDER = SudokuImportActivity.EXTRA_APPEND_TO_FOLDER;
+    public static final String EXTRA_NUM_GAMES = SudokuImportActivity.EXTRA_NUM_GAMES;
+    public static final String EXTRA_NUM_EMPTY_CELLS = SudokuImportActivity.EXTRA_NUM_EMPTY_CELLS;
+
+    private EditText mFolderNameEdit;
+    private NumberPicker mNumGamesPicker;
+    private NumberPicker mNumEmptyCellsPicker;
+    private CheckBox mAppendToFolderCb;
+
+    private GenImportTask mGenTask;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.sudoku_gen);
+
+        mFolderNameEdit = findViewById(R.id.gen_folder_name);
+        mNumGamesPicker = findViewById(R.id.gen_games);
+        mNumEmptyCellsPicker = findViewById(R.id.gen_empty_cells);
+        mAppendToFolderCb = findViewById(R.id.gen_append);
+
+        Intent intent = getIntent();
+        String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
+        mFolderNameEdit.setText(folderName == null
+                ? "Gen_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()
+                : folderName);
+
+        mNumEmptyCellsPicker.setMinValue(1);
+        mNumEmptyCellsPicker.setMaxValue(81);
+        mNumEmptyCellsPicker.setValue(intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 60));
+
+        mNumGamesPicker.setMinValue(1);
+        mNumGamesPicker.setMaxValue(100);
+        mNumGamesPicker.setValue(intent.getIntExtra(EXTRA_NUM_GAMES, 20));
+
+        mAppendToFolderCb.setChecked(intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false));
+
+        Button mGenButton = findViewById(R.id.gen_button);
+        mGenButton.setOnClickListener(v -> {
+            Intent i = new Intent(this, SudokuImportActivity.class);
+            i.putExtra(EXTRA_FOLDER_NAME, mFolderNameEdit.getText().toString());
+            i.putExtra(EXTRA_NUM_GAMES, mNumGamesPicker.getValue());
+            i.putExtra(EXTRA_NUM_EMPTY_CELLS, mNumEmptyCellsPicker.getValue());
+            i.putExtra(EXTRA_APPEND_TO_FOLDER, mAppendToFolderCb.isChecked());
+            startActivity(i);
+        });
+    }
+}

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
@@ -9,7 +9,7 @@ import android.widget.EditText;
 import android.widget.NumberPicker;
 
 import org.moire.opensudoku.R;
-import org.moire.opensudoku.gui.importing.GenImportTask;
+import org.moire.opensudoku.gui.importing.GenerateImportTask;
 
 import java.util.Date;
 
@@ -27,7 +27,7 @@ public class SudokuGenerateActivity extends ThemedActivity {
     private NumberPicker mNumEmptyCellsPicker;
     private CheckBox mAppendToFolderCb;
 
-    private GenImportTask mGenTask;
+    private GenerateImportTask mGenTask;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuGenerateActivity.java
@@ -43,23 +43,27 @@ public class SudokuGenerateActivity extends ThemedActivity {
         Intent intent = getIntent();
         String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
         mFolderNameEdit.setText(folderName == null
-                ? "Gen_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()
+                ? "Gen_"+DateFormat.format("yyyy-MM-dd-hh-mm-ss", new Date()).toString()+"_{games}x{empty}"
                 : folderName);
 
         mNumEmptyCellsPicker.setMinValue(1);
         mNumEmptyCellsPicker.setMaxValue(81);
-        mNumEmptyCellsPicker.setValue(intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 60));
+        mNumEmptyCellsPicker.setValue(intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 55));
 
         mNumGamesPicker.setMinValue(1);
         mNumGamesPicker.setMaxValue(100);
-        mNumGamesPicker.setValue(intent.getIntExtra(EXTRA_NUM_GAMES, 20));
+        mNumGamesPicker.setValue(intent.getIntExtra(EXTRA_NUM_GAMES, 5));
 
         mAppendToFolderCb.setChecked(intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false));
 
         Button mGenButton = findViewById(R.id.gen_button);
         mGenButton.setOnClickListener(v -> {
+            String folder = mFolderNameEdit.getText().toString()
+                    .replace("{games}", Integer.toString(mNumGamesPicker.getValue()))
+                    .replace("{empty}", Integer.toString(mNumEmptyCellsPicker.getValue()));
+
             Intent i = new Intent(this, SudokuImportActivity.class);
-            i.putExtra(EXTRA_FOLDER_NAME, mFolderNameEdit.getText().toString());
+            i.putExtra(EXTRA_FOLDER_NAME, folder);
             i.putExtra(EXTRA_NUM_GAMES, mNumGamesPicker.getValue());
             i.putExtra(EXTRA_NUM_EMPTY_CELLS, mNumEmptyCellsPicker.getValue());
             i.putExtra(EXTRA_APPEND_TO_FOLDER, mAppendToFolderCb.isChecked());

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
@@ -81,8 +81,8 @@ public class SudokuImportActivity extends ThemedActivity {
         } else if (intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 0) > 0) {
 
             String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
-            int numGames = intent.getIntExtra(EXTRA_NUM_GAMES, 20);
-            int numEmptyCells = intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 60);
+            int numGames = intent.getIntExtra(EXTRA_NUM_GAMES, 10);
+            int numEmptyCells = intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 55);
             boolean appendToFolder = intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false);
             importTask = new GenerateImportTask(folderName, numGames, numEmptyCells, appendToFolder);
 

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
@@ -4,8 +4,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.util.Log;
 import android.view.Window;
 import android.widget.ProgressBar;
@@ -14,6 +12,7 @@ import org.moire.opensudoku.R;
 import org.moire.opensudoku.gui.importing.AbstractImportTask;
 import org.moire.opensudoku.gui.importing.AbstractImportTask.OnImportFinishedListener;
 import org.moire.opensudoku.gui.importing.ExtrasImportTask;
+import org.moire.opensudoku.gui.importing.GenImportTask;
 import org.moire.opensudoku.gui.importing.OpenSudokuImportTask;
 import org.moire.opensudoku.gui.importing.SdmImportTask;
 import org.moire.opensudoku.utils.Const;
@@ -39,6 +38,8 @@ public class SudokuImportActivity extends ThemedActivity {
      * 120001232...0041\n 456000213...1100\n
      */
     public static final String EXTRA_GAMES = "GAMES";
+    public static final String EXTRA_NUM_GAMES = "NUM_GAMES";
+    public static final String EXTRA_NUM_EMPTY_CELLS = "NUM_EMPTY_CELLS";
 
     private static final String TAG = "ImportSudokuActivity";
 
@@ -77,6 +78,14 @@ public class SudokuImportActivity extends ThemedActivity {
                 return;
 
             }
+        } else if (intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 0) > 0) {
+
+            String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);
+            int numGames = intent.getIntExtra(EXTRA_NUM_GAMES, 20);
+            int numEmptyCells = intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 60);
+            boolean appendToFolder = intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false);
+            importTask = new GenImportTask(folderName, numGames, numEmptyCells, appendToFolder);
+
         } else if (intent.getStringExtra(EXTRA_FOLDER_NAME) != null) {
 
             String folderName = intent.getStringExtra(EXTRA_FOLDER_NAME);

--- a/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/SudokuImportActivity.java
@@ -12,7 +12,7 @@ import org.moire.opensudoku.R;
 import org.moire.opensudoku.gui.importing.AbstractImportTask;
 import org.moire.opensudoku.gui.importing.AbstractImportTask.OnImportFinishedListener;
 import org.moire.opensudoku.gui.importing.ExtrasImportTask;
-import org.moire.opensudoku.gui.importing.GenImportTask;
+import org.moire.opensudoku.gui.importing.GenerateImportTask;
 import org.moire.opensudoku.gui.importing.OpenSudokuImportTask;
 import org.moire.opensudoku.gui.importing.SdmImportTask;
 import org.moire.opensudoku.utils.Const;
@@ -84,7 +84,7 @@ public class SudokuImportActivity extends ThemedActivity {
             int numGames = intent.getIntExtra(EXTRA_NUM_GAMES, 20);
             int numEmptyCells = intent.getIntExtra(EXTRA_NUM_EMPTY_CELLS, 60);
             boolean appendToFolder = intent.getBooleanExtra(EXTRA_APPEND_TO_FOLDER, false);
-            importTask = new GenImportTask(folderName, numGames, numEmptyCells, appendToFolder);
+            importTask = new GenerateImportTask(folderName, numGames, numEmptyCells, appendToFolder);
 
         } else if (intent.getStringExtra(EXTRA_FOLDER_NAME) != null) {
 

--- a/app/src/main/java/org/moire/opensudoku/gui/importing/GenImportTask.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/importing/GenImportTask.java
@@ -1,0 +1,40 @@
+package org.moire.opensudoku.gui.importing;
+
+import org.moire.opensudoku.db.SudokuInvalidFormatException;
+import org.moire.opensudoku.gen.Generator;
+
+/**
+ * Handles import of puzzles via intent's extras.
+ *
+ * @author romario
+ */
+public class GenImportTask extends AbstractImportTask {
+
+    private String mFolderName;
+    private int mNumEmptyCells;
+    private int mNumGames;
+    private boolean mAppendToFolder;
+
+    public GenImportTask(String folderName, int numGames, int numEmptyCells, boolean appendToFolder) {
+        mFolderName = folderName;
+        mNumEmptyCells = numEmptyCells;
+        mNumGames = numGames;
+        mAppendToFolder = appendToFolder;
+    }
+
+    @Override
+    protected void processImport() throws SudokuInvalidFormatException {
+        if (mAppendToFolder) {
+            appendToFolder(mFolderName);
+        } else {
+            importFolder(mFolderName);
+        }
+
+        Generator g = new Generator();
+        for (int i=0; i<mNumGames; i++) {
+            String game = g.generateData(mNumEmptyCells);
+            importGame(game);
+        }
+    }
+
+}

--- a/app/src/main/java/org/moire/opensudoku/gui/importing/GenerateImportTask.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/importing/GenerateImportTask.java
@@ -1,7 +1,10 @@
 package org.moire.opensudoku.gui.importing;
 
+import android.util.Log;
+
 import org.moire.opensudoku.db.SudokuInvalidFormatException;
 import org.moire.opensudoku.game.SudokuGame;
+import org.moire.opensudoku.game.SudokuGenerator;
 
 /**
  * Handles import of puzzles via intent's extras.
@@ -9,6 +12,8 @@ import org.moire.opensudoku.game.SudokuGame;
  * @author romario
  */
 public class GenerateImportTask extends AbstractImportTask {
+
+    private static String TAG = GenerateImportTask.class.getName();
 
     private String mFolderName;
     private int mNumEmptyCells;
@@ -30,17 +35,14 @@ public class GenerateImportTask extends AbstractImportTask {
             importFolder(mFolderName);
         }
 
+        SudokuGenerator generator = new SudokuGenerator();
         for (int i=0; i<mNumGames; i++) {
-            SudokuGame game = SudokuGame.generateNewGame(mNumEmptyCells);
+            SudokuGame game = generator.generate(mNumEmptyCells);
             String data = game.toDataString();
             importGame(data);
         }
 
-//        Generator g = new Generator();
-//        for (int i=0; i<mNumGames; i++) {
-//            String game = g.generateData(mNumEmptyCells);
-//            importGame(game);
-//        }
+        Log.d(TAG, "processImport: Generating "+mNumGames+" games took "+generator.getTotalAttempts()+" attempts");
     }
 
 }

--- a/app/src/main/java/org/moire/opensudoku/gui/importing/GenerateImportTask.java
+++ b/app/src/main/java/org/moire/opensudoku/gui/importing/GenerateImportTask.java
@@ -1,21 +1,21 @@
 package org.moire.opensudoku.gui.importing;
 
 import org.moire.opensudoku.db.SudokuInvalidFormatException;
-import org.moire.opensudoku.gen.Generator;
+import org.moire.opensudoku.game.SudokuGame;
 
 /**
  * Handles import of puzzles via intent's extras.
  *
  * @author romario
  */
-public class GenImportTask extends AbstractImportTask {
+public class GenerateImportTask extends AbstractImportTask {
 
     private String mFolderName;
     private int mNumEmptyCells;
     private int mNumGames;
     private boolean mAppendToFolder;
 
-    public GenImportTask(String folderName, int numGames, int numEmptyCells, boolean appendToFolder) {
+    public GenerateImportTask(String folderName, int numGames, int numEmptyCells, boolean appendToFolder) {
         mFolderName = folderName;
         mNumEmptyCells = numEmptyCells;
         mNumGames = numGames;
@@ -30,11 +30,17 @@ public class GenImportTask extends AbstractImportTask {
             importFolder(mFolderName);
         }
 
-        Generator g = new Generator();
         for (int i=0; i<mNumGames; i++) {
-            String game = g.generateData(mNumEmptyCells);
-            importGame(game);
+            SudokuGame game = SudokuGame.generateNewGame(mNumEmptyCells);
+            String data = game.toDataString();
+            importGame(data);
         }
+
+//        Generator g = new Generator();
+//        for (int i=0; i<mNumGames; i++) {
+//            String game = g.generateData(mNumEmptyCells);
+//            importGame(game);
+//        }
     }
 
 }

--- a/app/src/main/res/layout/sudoku_dl.xml
+++ b/app/src/main/res/layout/sudoku_dl.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/dl_sudoku"
+        android:paddingTop="10dp"
+        android:paddingBottom="30dp"
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault.DialogWindowTitle" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:text="@string/folder" />
+
+    <EditText
+        android:id="@+id/dl_folder_name"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:inputType=""
+        android:singleLine="true" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:text="@string/dl_url" />
+
+    <EditText
+        android:id="@+id/dl_url"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:inputType=""
+        android:singleLine="true" />
+
+    <CheckBox
+        android:id="@+id/dl_append"
+        android:text="@string/append_to_folder"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/dl_button"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/dl_sudoku" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/sudoku_gen.xml
+++ b/app/src/main/res/layout/sudoku_gen.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/generate_sudoku"
+        android:paddingTop="10dp"
+        android:paddingBottom="30dp"
+        android:textAppearance="@android:style/TextAppearance.DeviceDefault.DialogWindowTitle" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:text="@string/add_folder" />
+
+    <EditText
+        android:id="@+id/gen_folder_name"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:inputType=""
+        android:singleLine="true" />
+
+    <GridLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:layout_gravity="center"
+        android:useDefaultMargins="true">
+
+        <TextView
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textStyle="bold"
+            android:text="@string/games"
+            android:gravity="center"
+            android:layout_row="0"
+            android:layout_column="0"
+            android:layout_columnWeight="1"/>
+
+        <NumberPicker
+            android:id="@+id/gen_games"
+            android:layout_height="wrap_content"
+            android:layout_row="1"
+            android:layout_column="0"
+            android:layout_columnWeight="1"
+            />
+
+        <TextView
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginTop="8dp"
+            android:text="@string/empty_cells"
+            android:layout_row="0"
+            android:layout_column="2"
+            android:layout_columnWeight="1" />
+
+        <NumberPicker
+            android:id="@+id/gen_empty_cells"
+            android:layout_height="wrap_content"
+            android:layout_row="1"
+            android:layout_column="2"
+            android:layout_columnWeight="1"/>
+
+    </GridLayout>
+
+    <CheckBox
+        android:id="@+id/gen_append"
+        android:text="@string/append_to_folder"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:layout_marginTop="8dp" />
+
+    <Button
+        android:id="@+id/gen_button"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/generate_sudoku" />
+
+</LinearLayout>

--- a/app/src/main/res/raw/changelog
+++ b/app/src/main/res/raw/changelog
@@ -1,6 +1,10 @@
 <html>
 <head><style type="text/css">body {font-size: smaller;}</style></head>
 <body>
+  <b>?.?.?</b>
+  <ul>
+    <li>Added ability to generate boards of varying difficulty. Thanks @chrisawad</li>
+  </ul>
   <b>3.4.1</b>
   <ul>
     <li>Improved SDM importer to support files with dots instead of zeros.</li>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,13 +44,6 @@
     <string name="select_number">Select number</string>
     <string name="edit_note">Edit note</string>
 
-
-    <string name="generate">Generate</string>
-    <string name="folder">Folder</string>
-    <string name="games">Games</string>
-    <string name="empty_cells">Empty Cells</string>
-    <string name="append_to_folder">Append to Folder</string>
-
     <string name="add_folder">Add folder</string>
     <string name="import_file">Import</string>
     <string name="import_file_title">Import file %s</string>
@@ -389,4 +382,11 @@
     <string name="sort_creation_date">Creation date</string>
     <string name="sort_play_time">Play time</string>
     <string name="sort_last_played">Last played</string>
+
+    <!-- Strings added/changed in ?.?.? -->
+    <string name="generate">Generate</string>
+    <string name="folder">Folder</string>
+    <string name="games">Games</string>
+    <string name="empty_cells">Empty Cells</string>
+    <string name="append_to_folder">Append to Folder</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,4 +389,7 @@
     <string name="games">Games</string>
     <string name="empty_cells">Empty Cells</string>
     <string name="append_to_folder">Append to Folder</string>
+    <string name="download">Download</string>
+    <string name="dl_url">Download URL</string>
+    <string name="dl_sudoku">Download Games</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,6 +44,13 @@
     <string name="select_number">Select number</string>
     <string name="edit_note">Edit note</string>
 
+
+    <string name="generate">Generate</string>
+    <string name="folder">Folder</string>
+    <string name="games">Games</string>
+    <string name="empty_cells">Empty Cells</string>
+    <string name="append_to_folder">Append to Folder</string>
+
     <string name="add_folder">Add folder</string>
     <string name="import_file">Import</string>
     <string name="import_file_title">Import file %s</string>
@@ -252,7 +259,8 @@
         @TacoTheDank\n
         @steve3424\n
         Chris Lane\n
-        Justin Nordin
+        Justin Nordin\n
+        Chris Awad
     </string>
 
     <!-- Strings added/changed in 2.5.0 -->

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 28 09:03:25 CEST 2020
+#Sun Aug 16 15:51:50 EDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip


### PR DESCRIPTION
I've added some code to SudokuGame, and CellCollection in order to generate new games. Basically all it does is use SudokuSolver to solve an empty board then randomly loops and unset x number of cells in that board. Very simple, but I am open to suggestions on better ways to generate new games.

I found that using 55 empty cells is pretty good for a very hard game. 60 empty cells became too difficult.

In order to facilitate the ability to generate and download multiple games at once, I've added 2 new activities (SudokuGenerateActivity and SudokuDownloadActivity) and a new task (GenerateImportTask) and integrated them into the existing import mechanisms.

https://opensudoku.moire.org/ doesn't expose the download link for generated games, so i cant really test SodokuDownloadActivity, but maybe someone has suggestions?

Let me know what you think!
 