### PR TITLE
Improved German translation

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -63,7 +63,7 @@
     <string name="clear_all_notes">Alle Notizen löschen</string>
     <string name="fill_in_notes">Notizen eintragen</string>
     <string name="restart">Spiel neu starten</string>
-    <string name="congrats">Herzlichen Glückwunsch, Du hast das Sudoku-Rätsel in %s gelöst.</string>
+    <string name="congrats">Herzlichen Glückwunsch, Sie haben das Sudoku-Rätsel in %s gelöst.</string>
     <string name="restart_confirm">Möchten Sie dieses Spiel wirklich neu starten?</string>
     <string name="well_done">Gut gemacht!</string>
     <string name="clear_all_notes_confirm">Möchten Sie wirklich alle Notizen löschen?</string>
@@ -77,7 +77,7 @@
     <string name="popup">Popup</string>
     <string name="popup_summary">Zahlen in einem Popup-Dialog bearbeiten.</string>
     <string name="single_number">Einzelne Zahl</string>
-    <string name="single_number_summary">Eine Zahl auswählen, danach auf eine Zelle tippen um den Wert oder die Notiz zu
+    <string name="single_number_summary">Eine Zahl auswählen, danach auf eine Zelle tippen, um den Wert oder die Notiz zu
 		setzen.
 	</string>
     <string name="numpad">Zahlenblock</string>
@@ -94,42 +94,42 @@
     <string name="that_is_all">Das ist alles!</string>
 
 
-    <string name="first_run_hint">Es stehen verschiedene Eingabe-Modi zum lösen der Sudoku-Rätsel zur Verfügung. Um Sie
+    <string name="first_run_hint">Es stehen verschiedene Eingabe-Modi zum Lösen der Sudoku-Rätsel zur Verfügung. Um Sie
 		mit diesen Modi vertraut zu machen, sehen Sie nun eine kurze Einführung.\n\nSie können diesen Hilfe-Text in den
 		Spiel-Einstellungen deaktivieren.\n
 	</string>
-    <string name="im_popup_hint">Sie befinden sich nun im<i>Popup</i>-Modus. Tippen Sie mit dem Finger auf eine Zelle um
+    <string name="im_popup_hint">Sie befinden sich nun im<i>Popup</i>-Modus. Tippen Sie mit dem Finger auf eine Zelle, um
 		diese zu bearbeiten\n\nBeachten Sie den Schalter in der unteren rechten Ecke. Über diese können Sie jederzeit
 		den Eingabe-Modus wechseln.\n
 	</string>
     <string name="im_single_number_hint">Sie befinden sich nun im<i>Einzelne Zahl</i>-Modus. Wählen Sie zunächst eine
 		Zahl aus. Dann tippen Sie die Zelle an, in die Sie die Zahl eintragen möchten.\n\nDrücken Sie die<i>Stift</i>
-		-Schaltfläche um Zellen-Notizen zu bearbeiten.\n
+		-Schaltfläche, um Zellen-Notizen zu bearbeiten.\n
 	</string>
     <string name="im_numpad_hint">Sie befinden sich nun im<i>Zahlenblock</i>-Modus. Die Zahlen von 1 bis 9 werden als
-		Bildschirm-Tastatur angezeigt.\n\nDrücken Sie die<i>Stift</i>-Schaltfläche um Zellen-Notizen zu bearbeiten.\n
+		Bildschirm-Tastatur angezeigt.\n\nDrücken Sie die<i>Stift</i>-Schaltfläche, um Zellen-Notizen zu bearbeiten.\n
 	</string>
     <string name="im_disable_modes_hint">Bitte beachten Sie, das Sie nicht alle Eingabe-Modi verwenden müssen. Sie
 		können einzelnen Eingabe-Modi in den Einstellungen deaktivieren.\n\nSie können auch den Trackball oder die
 		Tastatur zur Steuerung des Spiels verwenden. Wenn Sie Notizen über die Tastatur eingeben möchten, drücken "Alt"
 		oder "Umschalt" + Zahl.\n
 	</string>
-    <string name="help_text"><b>Tastatur-Steuerung</b>\n\nVerwenden Sie den Trackball um zur gewünschten Zelle zu
+    <string name="help_text"><b>Tastatur-Steuerung</b>\n\nVerwenden Sie den Trackball, um zur gewünschten Zelle zu
 		navigieren und drücken Sie dann eine Zahl auf der Tastatur. Um eine Zellen-Notiz zu bearbeiten, drücken Sie
 		Shift- oder Alt und die entsprechende Zahl.\n\n<b>Eingabe-Modi</b>\n\nÜber die Schaltfläche in der rechten
 		unteren Ecke können Sie zwischen verschiedenen Eingabe-Modi wechseln. Sie können jeden der Eingabe-Modi in den
-		Einstellungen deaktivieren.\n\n<b>Popup-Modus</b>\n\nTippen Sie mit dem Finger auf eine Zelle um diese in einem
+		Einstellungen deaktivieren.\n\n<b>Popup-Modus</b>\n\nTippen Sie mit dem Finger auf eine Zelle, um diese in einem
 		Dialogfeld zu bearbeiten.\n\n<b>Einzelne Zahl</b>\n\nWählen Sie zunächst eine Zahl aus. Dann tippen Sie die
-		Zelle an, in die Sie die Zahl eintragen möchten.\n\nDrücken Sie die<i>Stift</i>-Schaltfläche um Zellen-Notizen
+		Zelle an, in die Sie die Zahl eintragen möchten.\n\nDrücken Sie die<i>Stift</i>-Schaltfläche, um Zellen-Notizen
 		zu bearbeiten.\n
 	</string>
 
 
     <string name="game">Spiel</string>
-    <string name="show_hints">Zeige Bedienungsanleitung beim ersten Start</string>
-    <string name="show_hints_summary">Zeige Bedienungsanleitung</string>
-    <string name="show_time">Zeige Spiel-Zeit</string>
-    <string name="show_time_summary">Zeige Zeit während das Spiel läuft.</string>
+    <string name="show_hints">Zeige Bedienungsanleitung</string>
+    <string name="show_hints_summary">Zeige Bedienungsanleitung beim ersten Start</string>
+    <string name="show_time">Zeige Spielzeit</string>
+    <string name="show_time_summary">Zeige Zeit, während das Spiel läuft.</string>
 
     <string name="puzzle_inserted">Das neue Sudoku-Rätsel wurde gespeichert.</string>
     <string name="puzzle_updated">Das Sudoku-Rätsel wurde aktualisiert.</string>
@@ -144,7 +144,7 @@
 
     <!-- Strings added/changed in 0.7.1 -->
     <string name="more_settings">Mehr Einstellungen</string>
-    <string name="screen_border_size">Breite des Bildschirmrand</string>
+    <string name="screen_border_size">Breite des Bildschirmrandes</string>
     <string name="screen_border_size_summary">Spielfeld verkleinern, falls Ihr Bildschirm nicht auf Berührungen am
 		Bildschirmrand reagiert.
 	</string>
@@ -158,7 +158,7 @@
     <string name="exporting">Exportiere Sudoku-Rätsel…</string>
     <string name="unknown_export_error">Ein unbekannter Fehler ist während des Exports aufgetreten.</string>
     <string name="highlight_completed_values">Markiere vollständige Zahlen</string>
-    <string name="highlight_completed_values_summary">Markiere Zahlen die bereits vollständig eingegeben wurden.</string>
+    <string name="highlight_completed_values_summary">Markiere Zahlen, die bereits vollständig eingegeben wurden.</string>
     <string name="theme">Farbschema</string>
     <string name="theme_summary">Farbschema für das Spielfeld auswählen.</string>
     <string name="select_theme">Farbschema auswählen</string>
@@ -186,13 +186,13 @@
     <string name="show_number_totals">Zeige Anzahl gesetzter Zahlen</string>
     <string name="show_number_totals_summary">Zeigt auf der Tastatur, wie oft die jeweilige Zahl schon gesetzt wurde.</string>
     <string name="undo_to_checkpoint">Zurück zu Sicherungspunkt</string>
-    <string name="undo_to_checkpoint_confirm">Sind Sie sicher, alle Eingaben bis zum letzten Sicherungspunkt zu Verwerfen?</string>
+    <string name="undo_to_checkpoint_confirm">Sind Sie sicher, alle Eingaben bis zum letzten Sicherungspunkt zu verwerfen?</string>
     <string name="what_is_new">Neues</string>
     <string name="highlight_similar_cells">Hervorhebung ähnlicher Zellen</string>
     <string name="highlight_similar_cells_summary">Hebe Zellen mit gleichen Zahlen hervor.</string>
     <string name="contributors_label">Mitwirkende</string>
     <string name="bidirectional_selection">Bidirektionale Auswahl</string>
-    <string name="bidirectional_selection_summary">Im EZ Modus übernimmt die Auswahl einer feste Zahl die Zahl als nächste Eingabe.</string>
+    <string name="bidirectional_selection_summary">Im EZ-Modus übernimmt die Auswahl einer festen Zahl die Zahl als nächste Eingabe.</string>
 
     <!-- Strings added/changed in 2.5.0 -->
     <string name="game_state_not_started">neu</string>
@@ -209,18 +209,18 @@
     <string name="theme_paper_light">Papier Hell</string>
     <string name="theme_graph_paper_light">Karopapier Hell</string>
     <string name="theme_high_contrast">Hoher Kontrast</string>
-    <string name="theme_inverted_high_contrast">Invertierter Hoher Kontrast</string>
+    <string name="theme_inverted_high_contrast">Invertierter hoher Kontrast</string>
     <string name="theme_custom">Eigenes Thema</string>
 
     <string name="screen_custom_theme">Eigene Themenfarben</string>
     <string name="screen_custom_theme_summary">Verändere Farben des eigenen Themas.</string>
-    <string name="screen_custom_theme_summary_disabled">Wählen Sie \"Eigenes Thema\" in der Themenauswahl, um diese Einstellungen zu Aktivieren.</string>
+    <string name="screen_custom_theme_summary_disabled">Wählen Sie \"Eigenes Thema\" in der Themenauswahl, um diese Einstellungen zu aktivieren.</string>
 
     <string name="default_lineColor">Zellrahmen</string>
     <string name="default_lineColor_summary">Rahmen um eine einzelne Zelle</string>
 
     <string name="default_sectorLineColor">Sektorrahmen</string>
-    <string name="default_sectorLineColor_summary">Rahmen um einen Block 3x3 Zellen</string>
+    <string name="default_sectorLineColor_summary">Rahmen um einen Block 3x3-Zellen</string>
 
     <string name="default_textColor">Eingefügte Zahl</string>
     <string name="default_textColor_summary">Textfarbe einer editierbaren Zelle</string>
@@ -241,18 +241,18 @@
     <string name="default_backgroundColorReadOnly_summary">Hintergrundfarbe vorgegebener Zellen</string>
 
     <string name="default_backgroundColorTouched">Fadenkreuz</string>
-    <string name="default_backgroundColorTouched_summary">Hintergrundfarbe der aktuellen Reihe und Spalte während dem Auswählen einer neuen Zelle</string>
+    <string name="default_backgroundColorTouched_summary">Hintergrundfarbe der aktuellen Reihe und Spalte während des Auswählens einer neuen Zelle</string>
 
     <string name="default_backgroundColorSelected">Aktuelle Zelle</string>
     <string name="default_backgroundColorSelected_summary">Hintergrundfarbe der aktuell ausgewählten Zelle</string>
 
     <string name="default_backgroundColorHighlighted">Hintergrund hervorgehebene Zelle</string>
-    <string name="default_backgroundColorHighlighted_summary">Hintergrundfarbe der Zellen, die gleiche Zahl wie die aktuellen Zelle haben</string>
+    <string name="default_backgroundColorHighlighted_summary">Hintergrundfarbe der Zellen, die die gleiche Zahl wie die aktuelle Zelle haben</string>
     <string name="resume">Fortsetzen</string>
-    <string name="show_sudoku_lists_on_startup_summary">Sudokuliste zum Start anzeigen und Titelbildschirm überspringen</string>
-    <string name="show_sudoku_lists_on_startup_title">Sudokuliste zum Start anzeigen</string>
+    <string name="show_sudoku_lists_on_startup_summary">Sudoku-Liste zum Start anzeigen und Titelbildschirm überspringen.</string>
+    <string name="show_sudoku_lists_on_startup_title">Sudoku-Liste zum Start anzeigen</string>
     <string name="solve_puzzle">Puzzle lösen</string>
-    <string name="solve_puzzle_confirm">Möchtest du die Lösung wirklich sehen?</string>
+    <string name="solve_puzzle_confirm">Möchten Sie die Lösung wirklich sehen?</string>
     <string name="solver_hint">Hinweis</string>
     <string name="sort">Sortieren</string>
     <string name="sort_creation_date">Erstellungsdatum</string>
@@ -272,16 +272,16 @@
     <string name="theme_emerald">Smaragd</string>
     <string name="theme_ruby">Rubin</string>
     <string name="theme_sunrise">Sonnenaufgang</string>
-    <string name="undo_to_before_mistake">Rückgänging auf vor Fehler</string>
-    <string name="undo_to_before_mistake_confirm">Möchtest du wirklich alle Aktionen seit dem letzten lösbaren Zustand zurücksetzen?</string>
-    <string name="used_solver">Du hast die Hilfe genutzt um die Lösung zu sehen!</string>
+    <string name="undo_to_before_mistake">Rückgängig auf vor Fehler</string>
+    <string name="undo_to_before_mistake_confirm">Möchten Sie wirklich alle Aktionen seit dem letzten lösbaren Zustand zurücksetzen?</string>
+    <string name="used_solver">Sie haben die Hilfe genutzt, um die Lösung zu sehen!</string>
     <string name="cannot_give_hint">Es gibt keinen Hinweis für dieses Feld</string>
     <string name="check_solvabitily">Lösbarkeit prüfen</string>
     <string name="copy_from_existing_theme">Von existierendem Schema kopieren…</string>
     <string name="create_from_single_color">Aus einzelner Farbe erstellen…</string>
     <string name="highlight_similar_notes">Gleiche Notizen hervorheben</string>
     <string name="highlight_similar_notes_summary">Hebt Felder mit gleichen Notizwerten hervor</string>
-    <string name="hint_confirm">Dies wird den richtigen Wert in das gewählte Feld eintragen. Willst du das?</string>
+    <string name="hint_confirm">Dies wird den richtigen Wert in das gewählte Feld eintragen. Möchten Sie das?</string>
     <string name="is_light_theme_title">Helles Schema</string>
     <string name="puzzle_not_solved">Dieses Puzzle hat keine Lösung.</string>
     <string name="puzzle_solvable">Dieses Puzzle hat eine Lösung.</string>
@@ -292,7 +292,7 @@
     <string name="app_color_primary_title">Erste Appfarbe</string>
     <string name="app_color_button_title">Knopffarbe</string>
     <string name="app_color_accent_title">Akzentfarbe</string>
-    <string name="app_color_accent_summary">Diese Farbe wird benutzt um verschiedene Elemente zu akzentuieren</string>
+    <string name="app_color_accent_summary">Diese Farbe wird benutzt, um verschiedene Elemente zu akzentuieren</string>
     <string name="app_color_button_summary">Diese Farbe wird für Knöpfe benutzt</string>
     <string name="app_color_primary_summary">Diese Farbe wird für den Hintergrund der Titelzeile genutzt</string>
     <string name="app_color_secondary_summary">Diese Farbe wird für die Android-Statusleiste genutzt und ist normalerweise eine dunklere Version der ersten Appfarbe</string>


### PR DESCRIPTION
Some improvements of the German translation:

- Fixed typos
- Consequently used "Sie" instead of "Du" (it was mixed with a much higher number of "Sie", therefore I took this one as standard)
- Inserted some missing commas and periods
- Some more grammar improvements (capitalization, cases)