### PR TITLE
Enhance opensudoku.moire.org - fix #134

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,13 @@
 	  <li><a id="hard" href="#about-puzzles">Hard</a> (20 puzzles)</li>
 	  <li><a id="veryhard" href="#about-puzzles">Very Hard</a> (20 puzzles)</li>
 	</ul>
+
+	<div id="progressDisplay" style="display:none">
+		<p>
+			<label for="progress">Puzzles generation in progress...</label>
+			<progress id="progress" max="20" value="0"></progress>
+		</p>
+	</div>
 </div>
 
 <p>You can find more puzzles on the following pages.</p>

--- a/index.html
+++ b/index.html
@@ -52,14 +52,16 @@
   <li><a href="sudoku/very_hard.opensudoku">Very Hard</a> (100 puzzles)</li>
 </ul>
 
-<p>If you want more puzzles, the following links generate new ones every time you open them. Please note that puzzle generation takes a while, after clicking one of the following links, wait several seconds while it is generating. The page may seem to freeze!</p>
+<div id="puzzle-generation">
+	<p>If you want more puzzles, the following links generate new ones every time you open them. Please note that puzzle generation takes a while, after clicking one of the following links, wait several seconds while it is generating. The page may seem to freeze!</p>
 
-<ul id="generateLinks">
-  <li><a id="easy" href="#about-puzzles">Easy</a> (20 puzzles)</li>
-  <li><a id="medium" href="#about-puzzles">Medium</a> (20 puzzles)</li>
-  <li><a id="hard" href="#about-puzzles">Hard</a> (20 puzzles)</li>
-  <li><a id="veryhard" href="#about-puzzles">Very Hard</a> (20 puzzles)</li>
-</ul>
+	<ul id="generateLinks">
+	  <li><a id="easy" href="#about-puzzles">Easy</a> (20 puzzles)</li>
+	  <li><a id="medium" href="#about-puzzles">Medium</a> (20 puzzles)</li>
+	  <li><a id="hard" href="#about-puzzles">Hard</a> (20 puzzles)</li>
+	  <li><a id="veryhard" href="#about-puzzles">Very Hard</a> (20 puzzles)</li>
+	</ul>
+</div>
 
 <p>You can find more puzzles on the following pages.</p>
 
@@ -85,17 +87,16 @@
         </footer>
 
         <script src="javascripts/filesaver.min.js"></script>
-        <script src="javascripts/sudoku.js"></script>
         <script src="javascripts/opensudoku.js"></script>
 
-                  <script type="text/javascript">
+        <script type="text/javascript">
             var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
             document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
           </script>
           <script type="text/javascript">
             try {
               var pageTracker = _gat._getTracker("UA-6804437-5");
-            pageTracker._trackPageview();
+              pageTracker._trackPageview();
             } catch(err) {}
           </script>
 

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 </ul>
 
 <div id="puzzle-generation">
-	<p>If you want more puzzles, the following links generate new ones every time you open them. Please note that puzzle generation takes a while, after clicking one of the following links, wait several seconds while it is generating. The page may seem to freeze!</p>
+	<p>If you want more puzzles, the following links generate new ones every time you open them.</p>
 
 	<ul id="generateLinks">
 	  <li><a id="easy" href="#about-puzzles">Easy</a> (20 puzzles)</li>

--- a/index.html
+++ b/index.html
@@ -45,25 +45,25 @@
 <p>Open Sudoku can open sudoku files directly from the Web. Just click any link below and a folder with puzzles will be downloaded and imported directly into the Open Sudoku app.</p>
 
 <ul>
-<li><a href="sudoku/easy.opensudoku">Easy</a> (100 puzzles)</li>
-<li><a href="sudoku/medium.opensudoku">Medium</a> (100 puzzles)</li>
-<li><a href="sudoku/hard.opensudoku">Hard</a> (100 puzzles)</li>
-<li><a href="sudoku/very_hard.opensudoku">Very Hard</a> (100 puzzles)</li>
+  <li><a href="sudoku/easy.opensudoku">Easy</a> (100 puzzles)</li>
+  <li><a href="sudoku/medium.opensudoku">Medium</a> (100 puzzles)</li>
+  <li><a href="sudoku/hard.opensudoku">Hard</a> (100 puzzles)</li>
+  <li><a href="sudoku/very_hard.opensudoku">Very Hard</a> (100 puzzles)</li>
 </ul>
 
 <p>If you want more puzzles, the following links generate new ones every time you open them. Please note that puzzle generation takes a while, after clicking one of the following links, wait several seconds while it is generating. The page may seem to freeze!</p>
 
-<ul>
-<li><a id="easy" href="#about-puzzles">Easy</a> (20 puzzles)</li>
-<li><a id="medium" href="#about-puzzles">Medium</a> (20 puzzles)</li>
-<li><a id="hard" href="#about-puzzles">Hard</a> (20 puzzles)</li>
-<li><a id="veryhard" href="#about-puzzles">Very Hard</a> (20 puzzles)</li>
+<ul id="generateLinks">
+  <li><a id="easy" href="#about-puzzles">Easy</a> (20 puzzles)</li>
+  <li><a id="medium" href="#about-puzzles">Medium</a> (20 puzzles)</li>
+  <li><a id="hard" href="#about-puzzles">Hard</a> (20 puzzles)</li>
+  <li><a id="veryhard" href="#about-puzzles">Very Hard</a> (20 puzzles)</li>
 </ul>
 
 <p>You can find more puzzles on the following pages.</p>
 
 <ul>
-<li><a href="https://opensudoku.p43.eu/">P43</a>. The first list of gnome-sudoku/Open Sudoku files can be imported directly by the Open Sudoku app. The second one must be saved to the device and imported by either opening it with the Open Sudoku app or using the import option in the app menu.</li>
+  <li><a href="https://opensudoku.p43.eu/">P43</a>. The first list of gnome-sudoku/Open Sudoku files can be imported directly by the Open Sudoku app. The second one must be saved to the device and imported by either opening it with the Open Sudoku app or using the import option in the app menu.</li>
 </ul>
 
 <h3><a name="authors-and-contributors" class="anchor" href="#authors-and-contributors"><span class="octicon octicon-link"></span></a>Authors and Contributors</h3>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="google-site-verification" content="4jVqyKkI-GW97B880p9fJnn2y6nYhjNWbZZB8PfVL_U" />
     <link href='https://fonts.googleapis.com/css?family=Chivo:900' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen" />

--- a/javascripts/opensudoku.js
+++ b/javascripts/opensudoku.js
@@ -39,15 +39,22 @@ window.onload = function() {
 
   if (window.Worker) {
 	  
+	var progressBar = document.getElementById('progress');
+	  
 	// setup web worker
     sudokuWorker = new Worker('javascripts/worker.js');
     
     sudokuWorker.onmessage = function(msg) {
 	
+	  progressBar.value++
+		
       if (++counter === 20) {
     	  savePuzzles(selectedLevel);
+    	  document.getElementById('progressDisplay').style.display = 'none';
+    	  progressBar.value = 0
       }
       else {
+		// more puzzles need to be generated. Append last generated puzzle to the puzzles variable and trigger next generation
   	  
         var osformat = msg.data
                     .replace(/a/g, '0')
@@ -71,6 +78,8 @@ window.onload = function() {
   	  var level = event.target.id;
   	
       if(level) {
+		  
+		document.getElementById('progressDisplay').style.display = 'block';
   		
   	    event.preventDefault();
   	    

--- a/javascripts/opensudoku.js
+++ b/javascripts/opensudoku.js
@@ -53,6 +53,9 @@ window.onload = function() {
 	var level = event.target.id;
 	
     if(level) {
+		
+	  event.preventDefault();
+	  
 	  generateSudoku(level, 20);
 	}
 	

--- a/javascripts/opensudoku.js
+++ b/javascripts/opensudoku.js
@@ -6,6 +6,8 @@
  */
 
 function generateSudoku (level="easy", number=10) {
+	
+  // set .opensudoku file header
   var date = new Date().toJSON().slice(0,10);
   var header = '<?xml version="1.0" encoding="UTF-8"?>\n<opensudoku>\n';
   header += '  <name>' + level + ' generated at ' + date + '</name>\n';
@@ -17,6 +19,8 @@ function generateSudoku (level="easy", number=10) {
   header += '  <level>' + level + '</level>\n';
   header += '  <sourceURL>http://opensudoku.moire.org/#about-puzzles</sourceURL>\n'
   var footer = '</opensudoku>\n';
+  
+  // generate puzzles
   var puzzles = '';
   for (i = 0; i < number; i++) {
     var puzzle = sudoku.generate(level);
@@ -30,32 +34,28 @@ function generateSudoku (level="easy", number=10) {
                   .replace(/f/g, '000000');
     puzzles += '  <game data="' + osformat + '" />\n';
   }
-  return header + puzzles + footer;
+  
+  // generate and save .opensudoku file
+  var blob =  new Blob([header + puzzles + footer], {type: "text/xml"});
+  
+  let filePrefix = level === 'veryhard'? 'very_hard' : level;
+  
+  saveAs(blob, filePrefix +"_generated.opensudoku");
+  
 }
 
 window.onload = function() {
-  var easy = document.getElementById('easy');
-  var medium = document.getElementById("medium");
-  var hard = document.getElementById("hard");
-  var veryhard = document.getElementById("veryhard");
 
-  var data = [];
-  var properties = {type: 'text/xml'};
-
-  easy.onclick = function() {
-    var blob = new Blob([generateSudoku("easy", 20)], {type: "text/xml"});
-    saveAs(blob, "easy_generated.opensudoku");
+  var generateLinks = document.getElementById('generateLinks');
+  
+  generateLinks.onclick = function(event) {
+	  
+	var level = event.target.id;
+	
+    if(level) {
+	  generateSudoku(level, 20);
+	}
+	
   }
-  medium.onclick = function() {
-    var blob = new Blob([generateSudoku("medium", 20)], {type: "text/xml"});
-    saveAs(blob, "medium_generated.opensudoku");
-  }
-  hard.onclick = function() {
-    var blob = new Blob([generateSudoku("hard", 20)], {type: "text/xml"});
-    saveAs(blob, "hard_generated.opensudoku");
-  }
-  veryhard.onclick = function() {
-    var blob = new Blob([generateSudoku("veryhard", 20)], {type: "text/xml"});
-    saveAs(blob, "very_hard_generated.opensudoku");
-  }
+  
 }

--- a/javascripts/worker.js
+++ b/javascripts/worker.js
@@ -1,0 +1,11 @@
+// sudoku generation web worker
+
+importScripts('sudoku.js');
+
+onmessage = function(msg) {
+  
+  var puzzle = sudoku.generate(msg.data.level);
+  var serialized = sudoku.serialize(puzzle);
+    
+  postMessage(serialized);
+};

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -369,3 +369,21 @@ footer a:hover {
 
 /* Mobile Portrait Size to Mobile Landscape Size (devices and browsers) */
 @media only screen and (max-width: 479px) {}
+
+
+progress {
+  border-radius: 2px; 
+  height: .7em;
+}
+progress::-webkit-progress-bar {
+  background-color: transparent;
+  border-radius: 2px; 
+  border: 1px solid #6d6d6d;
+  border-radius: 7px;
+}
+progress::-webkit-progress-value {
+  background-color: #d5000d;
+}
+progress::-moz-progress-bar {
+  background-color: #d5000d;
+}


### PR DESCRIPTION
This pull request contains a set of enhancements to the opensudoku.moire.org web page:

* optimize display on mobile devices (add `viewport` meta tag to the page).
* run puzzle generation in the background so that the page doesn't freeze.
* display a progress bar during puzzle generation.

Screenshot:

![Screenshot_2021-12-21_11-21-50](https://user-images.githubusercontent.com/925443/146922035-bb56c790-acba-41db-8729-975566d90bc9.png)
